### PR TITLE
Use normal methods for blocking I/O

### DIFF
--- a/src/transferscript/server/main.py
+++ b/src/transferscript/server/main.py
@@ -36,7 +36,7 @@ class Visits(BaseModel):
 
 
 @app.get("/visits/{bl_name}")
-async def all_visit_info(bl_name: str):
+def all_visit_info(bl_name: str):
     query = (
         db_session.query(BLSession)
         .join(Proposal)
@@ -77,7 +77,7 @@ async def all_visit_info(bl_name: str):
 
 
 @app.get("/visits/{bl_name}/{visit_name}")
-async def visit_info(bl_name: str, visit_name: str):
+def visit_info(bl_name: str, visit_name: str):
     query = (
         db_session.query(BLSession)
         .join(Proposal)


### PR DESCRIPTION
FastAPI should run blocking I/O (such as SQLAlchemy queries) faster if it is not in an asynchronous method. This is because it will run non-asynchronous path operation functions in a thread which it then `await`s. See the bottom of https://fastapi.tiangolo.com/async/ and the "About `def` vs `async def`" section of https://fastapi.tiangolo.com/tutorial/sql-databases/