### PR TITLE
Allow modification of `rsync` destination directory structure and file names

### DIFF
--- a/src/murfey/utils/rsync.py
+++ b/src/murfey/utils/rsync.py
@@ -20,7 +20,7 @@ class RsyncPipe(Processor):
         root: Optional[Path] = None,
         notify: Optional[Callable[[Path], Optional[dict]]] = None,
         destination_structure: Optional[
-            Callable[[Path, Optional[Path]], Tuple[Path, str]]
+            Callable[[Path, Path], Tuple[Path, str]]
         ] = None,
     ):
         super().__init__(name=name)
@@ -80,7 +80,7 @@ class RsyncPipe(Processor):
             if self._destination_structure:
                 for f in divided_files[s]:
                     self._sub_structure, new_file_name = self._destination_structure(
-                        f, s
+                        s, f
                     )
                     self._single_rsync(
                         root,

--- a/src/murfey/utils/rsync.py
+++ b/src/murfey/utils/rsync.py
@@ -19,7 +19,9 @@ class RsyncPipe(Processor):
         name: str = "rsync_pipe",
         root: Optional[Path] = None,
         notify: Optional[Callable[[Path], Optional[dict]]] = None,
-        destination_structure: Optional[Callable[[Path], Tuple[Path, Path]]] = None,
+        destination_structure: Optional[
+            Callable[[Path, Optional[Path]], Tuple[Path, str]]
+        ] = None,
     ):
         super().__init__(name=name)
         self._finaldir = finaldir
@@ -77,12 +79,14 @@ class RsyncPipe(Processor):
         for s in divided_files.keys():
             if self._destination_structure:
                 for f in divided_files[s]:
-                    self._sub_structure, new_file_name = self._destination_structure(f)
+                    self._sub_structure, new_file_name = self._destination_structure(
+                        f, s
+                    )
                     self._single_rsync(
                         root,
                         self._sub_structure,
                         [f],
-                        file_name=new_file_name,
+                        file_name=Path(new_file_name),
                         retry=retry,
                     )
             else:

--- a/src/murfey/utils/rsync.py
+++ b/src/murfey/utils/rsync.py
@@ -104,6 +104,7 @@ class RsyncPipe(Processor):
             cmd.append(str(self._finaldir / sub_struct / file_name))
         else:
             cmd.append(str(self._finaldir / sub_struct) + "/")
+        self._transferring = True
         runner = procrunner.run(
             cmd,
             callback_stdout=self._parse_rsync_stdout,

--- a/tests/utils/test_rsync.py
+++ b/tests/utils/test_rsync.py
@@ -87,7 +87,7 @@ def test_rsync_pipe_from_monitor(tmp_path):
 
 
 def test_rsync_with_additional_structure_without_changing_file_name(tmp_path):
-    def _new_structure(p: Path, s: Path) -> Tuple[Path, str]:
+    def _new_structure(s: Path, p: Path) -> Tuple[Path, str]:
         new_name = p.name
         new_dest = s / "extra"
         return new_dest, new_name
@@ -111,7 +111,7 @@ def test_rsync_with_additional_structure_without_changing_file_name(tmp_path):
 
 
 def test_rsync_with_changed_file_name(tmp_path):
-    def _new_structure(p: Path, s: Path) -> Tuple[Path, str]:
+    def _new_structure(s: Path, p: Path) -> Tuple[Path, str]:
         new_name = p.name.replace("01", "05")
         return s, new_name
 

--- a/tests/utils/test_rsync.py
+++ b/tests/utils/test_rsync.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Tuple
+
 from murfey.utils.file_monitor import Monitor
 from murfey.utils.rsync import RsyncPipe
 
@@ -81,3 +84,27 @@ def test_rsync_pipe_from_monitor(tmp_path):
     monitor.wait()
     rp.wait()
     assert (destination / "file01.txt").exists()
+
+
+def test_rsync_with_additional_structure_without_changing_file_name(tmp_path):
+    def _new_structure(p: Path, s: Path) -> Tuple[Path, str]:
+        new_name = p.name
+        new_dest = s / "extra"
+        return new_dest, new_name
+
+    (tmp_path / "from").mkdir()
+    destination = tmp_path / "to"
+    destination.mkdir()
+    (destination / "extra").mkdir()
+    f01 = tmp_path / "from" / "file01.txt"
+    f01.touch()
+    monitor = Monitor(tmp_path / "from")
+    monitor.process(in_thread=True, sleep=0.1)
+    rp = RsyncPipe(destination, destination_structure=_new_structure)
+    monitor >> rp
+    rp.process(in_thread=True)
+    assert rp.thread
+    monitor.stop()
+    monitor.wait()
+    rp.wait()
+    assert (destination / "extra" / "file01.txt").exists()

--- a/tests/utils/test_rsync.py
+++ b/tests/utils/test_rsync.py
@@ -108,3 +108,26 @@ def test_rsync_with_additional_structure_without_changing_file_name(tmp_path):
     monitor.wait()
     rp.wait()
     assert (destination / "extra" / "file01.txt").exists()
+
+
+def test_rsync_with_changed_file_name(tmp_path):
+    def _new_structure(p: Path, s: Path) -> Tuple[Path, str]:
+        new_name = p.name.replace("01", "05")
+        return s, new_name
+
+    (tmp_path / "from").mkdir()
+    destination = tmp_path / "to"
+    destination.mkdir()
+    f01 = tmp_path / "from" / "file01.txt"
+    f01.touch()
+    monitor = Monitor(tmp_path / "from")
+    monitor.process(in_thread=True, sleep=0.1)
+    rp = RsyncPipe(destination, destination_structure=_new_structure)
+    monitor >> rp
+    rp.process(in_thread=True)
+    assert rp.thread
+    monitor.stop()
+    monitor.wait()
+    rp.wait()
+    assert not (destination / "file01.txt").exists()
+    assert (destination / "file05.txt").exists()


### PR DESCRIPTION
This will be useful for tomography data sets which require a file name conversion before processing.

A function that takes the default file names and directory structure and returns modified versions can be passed to `RsyncPipe` for this purpose