### PR TITLE
Introduce client bootstrapping mechanism

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include LICENSE
+include README.md
+
+recursive-include src/murfey/templates *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+

--- a/pip_bootstrap.md
+++ b/pip_bootstrap.md
@@ -1,4 +1,0 @@
-How to bootstrap pip without pip being present on the system:
-
-curl -sOL https://files.pythonhosted.org/packages/py3/p/pip/pip-21.3.1-py3-none-any.whl
-python pip-21.3.1-py3-none-any.whl/pip install pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ server =
     importlib_resources; python_version<'3.9'
     ispyb
     jinja2
+    packaging
     uvicorn[standard]
     zocalo
 client =

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,9 +17,9 @@ project-urls =
 
 [options]
 packages =
+    murfey.bootstrap
     murfey.client
     murfey.server
-    murfey.bootstrap
 package_dir =
     =src
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,10 @@ project-urls =
     GitHub = https://github.com/DiamondLightSource/python-murfey
 
 [options]
-packages = find:
+packages =
+    murfey.client
+    murfey.server
+    murfey.bootstrap
 package_dir =
     =src
 python_requires = >=3.8
@@ -24,6 +27,7 @@ zip_safe = False
 
 [options.entry_points]
 console_scripts =
+    murfey = murfey.client.main:run
     murfey.client = murfey.client.main:run
     murfey.server = murfey.server:run
 

--- a/src/murfey/bootstrap/__main__.py
+++ b/src/murfey/bootstrap/__main__.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import shelve
+import subprocess
+import sys
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+# A script to simplify installing Murfey on a network-isolated machine.
+# This could in theory be invoked by
+#   python -m murfey.bootstrap
+# but then you would already have murfey installed, so what is the point.
+# More commonly this file will be run directly from a wheel with
+#   python murfey.whl/murfey/bootstrap
+# In this constellation you can not import any other files from the murfey
+# package. If you absolutely have to do this then look at the pip package
+# how this can be achieved. Also note that only standard library imports
+# will be available at that installation stage.
+
+
+def _download_to_file(url: str, outfile: str):
+    """
+    Downloads a single URL to a file.
+    """
+    with contextlib.closing(urlopen(url)) as socket:
+        file_size = socket.info().get("Content-Length")
+        if file_size:
+            file_size = int(file_size)
+        # There is no guarantee that the content-length header is set
+        received = 0
+        block_size = 8192
+        # Allow for writing the file immediately so we can empty the buffer
+        with open(outfile, mode="wb") as f:
+            while True:
+                block = socket.read(block_size)
+                received += len(block)
+                f.write(block)
+                if not block:
+                    break
+
+    if file_size and file_size != received:
+        raise OSError(
+            f"Error downloading {url}: received {received} bytes instead of expected {file_size} bytes"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser("murfey.bootstrap")
+    parser.add_argument("-?", action="help", help=argparse.SUPPRESS)
+    parser.add_argument(
+        type=str, dest="server", help="URL pointing to the murfey server"
+    )
+    args = parser.parse_args()
+
+    # Validate the passed server address and construct a minimal base path string and
+    # extract the host name for pip installation purposes
+    try:
+        murfey_url = urlparse(args.server)
+    except Exception:
+        exit(f"{args.server} is not a valid URL")
+    murfey_base = f"{murfey_url.scheme}://{murfey_url.netloc}"
+    murfey_hostname = murfey_url.netloc.split(":")[0]
+
+    print(f"Python version: {sys.version_info.major}.{sys.version_info.minor}")
+    if sys.hexversion < 0x3080000:
+        exit(
+            "Your python version is too old to support Murfey. "
+            "You need at least Python 3.8"
+        )
+
+    print()
+    print(f"1/3 -- Connecting to murfey server on {murfey_base}...")
+    _download_to_file(f"{murfey_base}/bootstrap/pip.whl", "pip.whl")
+
+    print()
+    print("2/3 -- Bootstrapping pip")
+    python = sys.executable
+    result = subprocess.run(
+        [
+            python,
+            "pip.whl/pip",
+            "install",
+            "--trusted-host",
+            murfey_hostname,
+            "-i",
+            f"{murfey_base}/pypi",
+            "pip",
+        ]
+    )
+    if result.returncode:
+        exit("Could not bootstrap pip")
+    os.remove("pip.whl")
+
+    print()
+    print("3/3 -- Installing murfey client")
+    result = subprocess.run(
+        [
+            python,
+            "-mpip",
+            "install",
+            "--trusted-host",
+            murfey_hostname,
+            "-i",
+            f"{murfey_base}/pypi",
+            "murfey[client]",
+        ]
+    )
+    if result.returncode:
+        exit("Could not install murfey client")
+
+    print()
+    print("Installation completed.")
+    with shelve.open("~/.murfey") as db:
+        db["server"] = murfey_base

--- a/src/murfey/bootstrap/__main__.py
+++ b/src/murfey/bootstrap/__main__.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import argparse
+import configparser
 import contextlib
 import os
-import shelve
+import pathlib
 import subprocess
 import sys
 from urllib.parse import urlparse
@@ -113,5 +114,7 @@ if __name__ == "__main__":
 
     print()
     print("Installation completed.")
-    with shelve.open("~/.murfey") as db:
-        db["server"] = murfey_base
+    config = configparser.ConfigParser()
+    config["Murfey"] = {"Server": murfey_base}
+    with open(pathlib.Path.home() / ".murfey", "w") as configfile:
+        config.write(configfile)

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -51,12 +51,10 @@ def get_db() -> sqlalchemy.orm.Session:
 # This will be the homepage for a given microscope.
 @app.get("/")
 async def root(request: Request, response_class=HTMLResponse):
-    client_host = request.client.host
     return templates.TemplateResponse(
         "home.html",
         {
             "request": request,
-            "client_host": client_host,
             "hostname": get_hostname(),
             "microscope": get_microscope(),
             "version": murfey.__version__,
@@ -70,7 +68,6 @@ def bootstrap(request: Request, response_class=HTMLResponse):
         "bootstrap.html",
         {
             "request": request,
-            "client_host": request.client.host,
             "hostname": get_hostname(),
             "microscope": get_microscope(),
             "version": murfey.__version__,

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -179,14 +179,12 @@ def visit_info(
 
 @app.get("/pypi/")
 def pypi_request():
-    """Obtain list of all packagess from PyPI via the simple API (PEP 503).
-    (Should we really support this?)"""
-    full_path = "https://pypi.org/simple/"
-    full_path_response = get(full_path)
+    """Obtain list of all PyPI packages via the simple API (PEP 503)."""
+    index = get("https://pypi.org/simple/")
     return Response(
-        content=full_path_response.content,
-        media_type=full_path_response.headers["Content-Type"],
-        status_code=200,
+        content=index.content,
+        media_type=index.headers["Content-Type"],
+        status_code=index.status_code,
     )
 
 

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -225,7 +225,7 @@ def pypi_download_request(package: str, filename: str):
     filename_bytes = re.escape(filename.encode("latin1"))
 
     selected_package_link = re.search(
-        b'<a [^>]*href="([^">]*)"[^>]*>' + filename_bytes + b"</a>",
+        b'<a [^>]*?href="([^">]*)"[^>]*>' + filename_bytes + b"</a>",
         full_path_response.content,
     )
     if not selected_package_link:

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -222,7 +222,7 @@ def pypi_package_request(package: str):
 def pypi_download_request(package: str, filename: str):
     """Obtain and pass through a specific download for a PyPI package."""
     full_path_response = get(f"https://pypi.org/simple/{package}")
-    filename_bytes = filename.encode("latin1")
+    filename_bytes = re.escape(filename.encode("latin1"))
 
     selected_package_link = re.search(
         b'<a [^>]*href="([^">]*)"[^>]*>' + filename_bytes + b"</a>",

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -243,6 +243,11 @@ def pypi_download_request(package: str, filename: str):
     )
 
 
+@app.get("/bootstrap/pip.whl")
+def pypi_download_pip():
+    return pypi_download_request(package="pip", filename="pip-21.3.1-py3-none-any.whl")
+
+
 class File(BaseModel):
     name: str
     description: str

--- a/src/murfey/templates/base.html
+++ b/src/murfey/templates/base.html
@@ -1,0 +1,20 @@
+<html><head>
+  <title>Murfey - {% block title %}{% endblock %}</title>
+  <link href="{{ url_for('static', path='/styles.css') }}" rel="stylesheet" />
+  <link href="{{ url_for('images', path='/icon_268.png') }}" rel="icon" type="image/png" />
+</head><body>
+  <div class="topnav">
+    <a href="/">Home</a>
+    <a href="/visits">Active Visits</a>
+    <a href="/bootstrap">Installation instructions</a>
+    <a href="/pypi/fastapi">FastAPI PyPI</a>
+    <p style="text-align: right; margin: 8px 10px 0 auto;"><img src="{{ url_for('images', path='/diamond.png') }}" style="height: 25px;"></p>
+  </div>
+
+  <div class="content">{% block content %}{% endblock %}</div>
+
+  <div class="footer">
+    <p>For help please contact your local contact or the EM Data Analysis team.</p>
+    <p style="font-size:60%">Murfey v{{ version }} running on {{ hostname }} ({{ microscope }})</p>
+  </div>
+</body></html>

--- a/src/murfey/templates/bootstrap.html
+++ b/src/murfey/templates/bootstrap.html
@@ -7,8 +7,8 @@
     <p>You can install Murfey on a network-isolated client by running the following commands:</p>
     <pre style="font-family: monospace">
       curl -O {{ request.url }}/pip.whl
-      python pip.whl/pip install -i {{ request.url.replace(path='/pypi') }} pip
+      python pip.whl/pip install --trusted-host {{ request.url.hostname }} -i {{ request.url.replace(path='/pypi') }} pip
       rm pip.whl
-      python -mpip install -i {{ request.url.replace(path='/pypi') }} murfey
+      python -mpip install --trusted-host {{ request.url.hostname }} -i {{ request.url.replace(path='/pypi') }} murfey
     </pre>
 {% endblock %}

--- a/src/murfey/templates/bootstrap.html
+++ b/src/murfey/templates/bootstrap.html
@@ -4,9 +4,11 @@
 
 {% block content %}
     <h1>Bootstrapping instructions</h1>
-    <p>How to bootstrap pip without pip being present on the system:</p>
-    <pre>
-      curl -sOL https://{{ hostname }}:{{ port }}/packages/py3/p/pip/pip-21.3.1-py3-none-any.whl
-      python pip-21.3.1-py3-none-any.whl/pip install pip
+    <p>You can install Murfey on a network-isolated client by running the following commands:</p>
+    <pre style="font-family: monospace">
+      curl -O {{ request.url }}/pip.whl
+      python pip.whl/pip install -i {{ request.url.replace(path='/pypi') }} pip
+      rm pip.whl
+      python -mpip install -i {{ request.url.replace(path='/pypi') }} murfey
     </pre>
 {% endblock %}

--- a/src/murfey/templates/bootstrap.html
+++ b/src/murfey/templates/bootstrap.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block title %}Bootstrapping instructions{% endblock %}
+
+{% block content %}
+    <h1>Bootstrapping instructions</h1>
+    <p>How to bootstrap pip without pip being present on the system:</p>
+    <pre>
+      curl -sOL https://{{ hostname }}:{{ port }}/packages/py3/p/pip/pip-21.3.1-py3-none-any.whl
+      python pip-21.3.1-py3-none-any.whl/pip install pip
+    </pre>
+{% endblock %}

--- a/src/murfey/templates/bootstrap.html
+++ b/src/murfey/templates/bootstrap.html
@@ -6,9 +6,8 @@
     <h1>Bootstrapping instructions</h1>
     <p>You can install Murfey on a network-isolated client by running the following commands:</p>
     <pre style="font-family: monospace">
-      curl -O {{ request.url }}/pip.whl
-      python pip.whl/pip install --trusted-host {{ request.url.hostname }} -i {{ request.url.replace(path='/pypi') }} pip
-      rm pip.whl
-      python -mpip install --trusted-host {{ request.url.hostname }} -i {{ request.url.replace(path='/pypi') }} murfey
+      curl -O {{ request.url.scheme }}://{{ request.url.netloc }}/bootstrap/murfey.whl
+      python murfey.whl/murfey/bootstrap {{ request.url.scheme }}://{{ request.url.netloc }}
+      rm murfey.whl
     </pre>
 {% endblock %}

--- a/src/murfey/templates/home.html
+++ b/src/murfey/templates/home.html
@@ -1,28 +1,8 @@
-<html>
-<head>
-    <title>MURFEY</title>
-    <link href="{{ url_for('static', path='/styles.css') }}" rel="stylesheet">
-    <link href="{{ url_for('images', path='/icon_268.png') }}" rel="icon" type="image/png" />
-</head>
+{% extends "base.html" %}
 
-<body>
-<div class="topnav">
-    <a href="/">Home</a>
-    <a href="/visits">Active Visits</a>
-    <a href="/pypi/fastapi">FastAPI PyPI</a>
-    <p style="text-align: right; margin: 8px 10px 0 auto;"><img src="{{ url_for('images', path='/diamond.png') }}" style="height: 25px;"></p>
-</div>
+{% block title %}MURFEY{% endblock %}
 
-
-<div class="content">
+{% block content %}
     <h1>{{ microscope }}</h1>
     <p>A transporter for data from Diamond eBIC microscope and detector machines onto the Diamond network.</p>
-</div>
-
-<div class="footer">
-    <p>For help please contact your LC or the EM Data Analysis team.</p>
-</div>
-
-</body>
-
-</html>
+{% endblock %}


### PR DESCRIPTION
On the server:
* Modify endpoint `/pypi/package` to rewrite the response and change all URLs to point to an endpoint `/pypi/package/file` instead
* Add endpoint `/pypi/package/file` which then downloads and passes through a particular file download
* Add endpoint `/bootstrap` pointing to an instruction page on how to install the client via a non-public network. The user is instructed to download a murfey wheel file, then run `murfey.bootstrap` from _within the wheel_ (ie. this calls the file `src/murfey/bootstrap/__main__.py`, and is not a command/entry point `murfey.bootstrap`)
* Add endpoint `/bootstrap/pip.whl` which downloads one particular version of pip from pypi
* Add endpoint `/bootstrap/murfey.whl` which downloads the most recent version of a murfey wheel
* The latter two endpoints are intended to be used during the bootstrap procedure.
* Add `src/murfey/bootstrap/__main__.py` which is a single python file separate from the rest of the package which can run in isolation and installs pip, murfey, and creates a murfey configuration file in `~/.murfey` with a pointer to the server