### PR TITLE
Add websockets support

### DIFF
--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -6,8 +6,7 @@ import pathlib
 import threading
 
 import murfey.client.update
-from murfey.client.main import (
-    close_websocket_connection,
+from murfey.client.main import (  # close_websocket_connection,
     open_websocket_connection,
     receive_messages,
 )
@@ -29,7 +28,7 @@ def run():
     receive = threading.Thread(receive_messages(ws))
     receive.start()
     # if file gets transferred, post request with message and ws object
-    close_websocket_connection(ws)
+    # close_websocket_connection(ws)
 
     if not args.server:
         exit("Murfey server not set. Please run with --server")
@@ -52,6 +51,12 @@ def run():
             murfey.client.update.check(args.server)
         except Exception as e:
             print(f"Murfey update check failed with {e}")
+
+    try:
+        while True:
+            pass
+    except Exception:
+        return 0
 
 
 def read_config() -> configparser.ConfigParser:

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -6,10 +6,7 @@ import pathlib
 import threading
 
 import murfey.client.update
-from murfey.client.main import (  # close_websocket_connection,
-    open_websocket_connection,
-    receive_messages,
-)
+from murfey.client.main import websocket_app
 
 
 def run():
@@ -24,9 +21,16 @@ def run():
     parser.add_argument("--visit", help="Name of visit", required=True)
     # visit_name = parser.parse_args().visit
 
-    ws = open_websocket_connection()
-    receive = threading.Thread(receive_messages(ws))
-    receive.start()
+    ws = threading.Thread(websocket_app())
+    ws.start()
+
+    # try:
+    #    while True:
+    # print(ws.connected)
+    #        time.sleep(5)
+    # except Exception:
+    #    return 0
+
     # if file gets transferred, post request with message and ws object
     # close_websocket_connection(ws)
 
@@ -51,12 +55,6 @@ def run():
             murfey.client.update.check(args.server)
         except Exception as e:
             print(f"Murfey update check failed with {e}")
-
-    try:
-        while True:
-            pass
-    except Exception:
-        return 0
 
 
 def read_config() -> configparser.ConfigParser:

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import argparse
 import configparser
 import pathlib
+import threading
 
 import murfey.client.update
-
-from murfey.client.main import example_websocket_connection, post_file
+from murfey.client.main import (
+    close_websocket_connection,
+    open_websocket_connection,
+    receive_messages,
+)
 
 
 def run():
@@ -19,12 +23,13 @@ def run():
     )
     args = parser.parse_args()
     parser.add_argument("--visit", help="Name of visit", required=True)
-    visit_name = parser.parse_args().visit
-    example_websocket_connection(visit_name)
-    post_file(visit_name)
-    # print("Visit name: ", args.visit)
-    # print(get_all_visits().text)
-    # print(get_visit_info(args.visit).text)
+    # visit_name = parser.parse_args().visit
+
+    ws = open_websocket_connection()
+    receive = threading.Thread(receive_messages(ws))
+    receive.start()
+    # if file gets transferred, post request with message and ws object
+    close_websocket_connection(ws)
 
     if not args.server:
         exit("Murfey server not set. Please run with --server")

--- a/src/murfey/client/main.py
+++ b/src/murfey/client/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import pathlib
+import random
 from typing import List, NamedTuple, Union
 
 import requests
@@ -16,23 +17,23 @@ class MonitoringPipeline(NamedTuple):
     rsync: RsyncPipe
 
 
-def example_websocket_connection(visit_name):
-    ws = create_connection("ws://127.0.0.1:8000/ws/test")
-    send_message(ws)
+def open_websocket_connection():
+    id = str(random.randint(0, 100))
+    url = "ws://127.0.0.1:8000/ws/" + id
+    ws = create_connection(url)
+    print(f"Websocket connection opened for Client {id}")
+    return ws
 
 
-def send_message(ws):
-    print("Sending message 1")
-    ws.send("Message 1")
+def receive_messages(ws):
     result = ws.recv()
     print("Received ", result)
+    # Do other stuff with the received message
+
+
+def close_websocket_connection(ws):
+    print("Closing websocket connection")
     ws.close()
-
-
-def post_file(visit):
-    url = "http://127.0.0.1:8000/visits/" + visit + "/files"
-    data = {"name": "file1", "description": "8361", "size": 25, "timestamp": 24.0}
-    requests.post(url, json=data)
 
 
 def get_all_visits() -> Union[dict, List[dict]]:

--- a/src/murfey/client/main.py
+++ b/src/murfey/client/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 import os
 import pathlib
 import random
@@ -48,7 +49,10 @@ def on_error(ws, error):
     ws.close()
 
 
-def on_close():
+def on_close(ws, url):
+    print("Closing connection")
+    ws.close()
+    # requests.delete(url)
     print("### closed ###")
 
 
@@ -60,8 +64,9 @@ def websocket_app():
     websocket.enableTrace(True)
     id = str(random.randint(0, 100))
     url = "ws://127.0.0.1:8000/ws/test/" + id
-    ws = websocket.WebSocketApp(url, on_error=on_error)
+    ws = websocket.WebSocketApp(url)
     ws.run_forever()
+    atexit.register(on_close, ws, url)
 
 
 def get_all_visits() -> Union[dict, List[dict]]:

--- a/src/murfey/client/main.py
+++ b/src/murfey/client/main.py
@@ -6,6 +6,7 @@ import random
 from typing import List, NamedTuple, Union
 
 import requests
+import websocket
 from websocket import create_connection
 
 from murfey.utils.file_monitor import Monitor
@@ -19,21 +20,48 @@ class MonitoringPipeline(NamedTuple):
 
 def open_websocket_connection():
     id = str(random.randint(0, 100))
-    url = "ws://127.0.0.1:8000/ws/" + id
+    url = "ws://127.0.0.1:8000/ws/test/" + id
     ws = create_connection(url)
+    print(ws.connected)
     print(f"Websocket connection opened for Client {id}")
     return ws
 
 
 def receive_messages(ws):
-    result = ws.recv()
-    print("Received ", result)
+    while True:
+        result = ws.recv()
+        print("Received ", result)
     # Do other stuff with the received message
 
 
 def close_websocket_connection(ws):
     print("Closing websocket connection")
     ws.close()
+
+
+def on_message(message):
+    print(message)
+
+
+def on_error(ws, error):
+    # print(error.text)
+    ws.close()
+
+
+def on_close():
+    print("### closed ###")
+
+
+def on_open():
+    print("Opened connection")
+
+
+def websocket_app():
+    websocket.enableTrace(True)
+    id = str(random.randint(0, 100))
+    url = "ws://127.0.0.1:8000/ws/test/" + id
+    ws = websocket.WebSocketApp(url, on_error=on_error)
+    ws.run_forever()
 
 
 def get_all_visits() -> Union[dict, List[dict]]:

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -165,7 +165,7 @@ class File(BaseModel):
 @app.post("/visits/{visit_name}/files")
 async def add_file(file: File):
     print("File POST received")
-    ws.update_clients(file)
+    await ws.update_clients(file)
     return file
 
 

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -165,7 +165,9 @@ class File(BaseModel):
 @app.post("/visits/{visit_name}/files")
 async def add_file(file: File):
     print("File POST received")
-    await ws.update_clients(file)
+    await ws.manager.queue.put(file)
+    # await ws.update_clients(file)
+    print("after await")
     return file
 
 

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 import murfey
 import murfey.server.bootstrap
+import murfey.server.websocket as ws
 from murfey.server import get_hostname, get_microscope, template_files, templates
 
 tags_metadata = [murfey.server.bootstrap.tag]
@@ -164,12 +165,7 @@ class File(BaseModel):
 @app.post("/visits/{visit_name}/files")
 async def add_file(file: File):
     print("File POST received")
-    # Want to tell if a file is the first to be transferred.
-    # Check if ISPyB has a Data Collection for that visit
-    # but there may be multiple Data Collections for a single visit.
-
-    # client_id = get_hostname()
-
+    ws.update_clients(file)
     return file
 
 

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -5,7 +5,7 @@ import datetime
 import ispyb
 import packaging.version
 import sqlalchemy.orm
-from fastapi import Depends, FastAPI, Request, WebSocket, WebSocketDisconnect
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from ispyb.sqlalchemy import BLSession, Proposal
@@ -24,6 +24,7 @@ app.mount("/images", StaticFiles(directory=template_files / "images"), name="ima
 
 app.include_router(murfey.server.bootstrap.bootstrap)
 app.include_router(murfey.server.bootstrap.pypi)
+app.include_router(murfey.server.websocket.ws)
 
 SessionLocal = sqlalchemy.orm.sessionmaker(
     bind=sqlalchemy.create_engine(
@@ -163,19 +164,13 @@ class File(BaseModel):
 @app.post("/visits/{visit_name}/files")
 async def add_file(file: File):
     print("File POST received")
+    # Want to tell if a file is the first to be transferred.
+    # Check if ISPyB has a Data Collection for that visit
+    # but there may be multiple Data Collections for a single visit.
+
+    # client_id = get_hostname()
+
     return file
-
-
-@app.websocket("/ws/test")
-async def websocket_endpoint(websocket: WebSocket):
-    await websocket.accept()
-    try:
-        while True:
-            data = await websocket.receive_text()
-            print("Received data: {}".format(data))
-            await websocket.send_text("Message from server")
-    except WebSocketDisconnect:
-        print("Client disconnected")
 
 
 @app.get("/version")

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -165,7 +165,7 @@ class File(BaseModel):
 @app.post("/visits/{visit_name}/files")
 async def add_file(file: File):
     print("File POST received")
-    await ws.manager.queue.put(file)
+    await ws.manager.broadcast(f"File {file} transferred")
     # await ws.update_clients(file)
     print("after await")
     return file

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -29,16 +29,19 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
-@ws.websocket("/ws/test")
-async def update_clients(websocket: WebSocket, client_id):
-    await manager.connect(websocket)
+@ws.websocket("/ws/{client_id}")
+async def manage_connection(websocket: WebSocket, client_id: str):
     try:
-        while True:
-            data = await websocket.receive_text()
-            print("Received data: {}".format(data))
-            await manager.send_individual_message(f"Received {data}", websocket)
-            await manager.broadcast(f"Client {client_id} sent {data}")
+        await manager.connect(websocket)
     except WebSocketDisconnect:
         manager.disconnect(websocket)
         await manager.broadcast(f"Client {client_id} disconnected")
+        print("Client disconnected")
+
+
+def update_clients(file_name):
+    try:
+        await manager.broadcast(f"File transferred {file_name}")
+    except WebSocketDisconnect:
+        await manager.broadcast("Client disconnected")
         print("Client disconnected")

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+ws = APIRouter(prefix="/ws", tags=["websocket"])
+
+
+class ConnectionManager:
+    def __init__(self):
+        self.active_connections: List[WebSocket] = []
+
+    async def connect(self, websocket: WebSocket):
+        await websocket.accept()
+        self.active_connections.append(websocket)
+
+    def disconnect(self, websocket: WebSocket):
+        self.active_connections.remove(websocket)
+
+    async def send_individual_message(self, message: str, websocket: WebSocket):
+        await websocket.send_text(message)
+
+    async def broadcast(self, message: str):
+        for connection in self.active_connections:
+            await connection.send_text(message)
+
+
+manager = ConnectionManager()
+
+
+@ws.websocket("/ws/test")
+async def update_clients(websocket: WebSocket, client_id):
+    await manager.connect(websocket)
+    try:
+        while True:
+            data = await websocket.receive_text()
+            print("Received data: {}".format(data))
+            await manager.send_individual_message(f"Received {data}", websocket)
+            await manager.broadcast(f"Client {client_id} sent {data}")
+    except WebSocketDisconnect:
+        manager.disconnect(websocket)
+        await manager.broadcast(f"Client {client_id} disconnected")
+        print("Client disconnected")

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import List
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
@@ -10,6 +11,7 @@ ws = APIRouter(prefix="/ws", tags=["websocket"])
 class ConnectionManager:
     def __init__(self):
         self.active_connections: List[WebSocket] = []
+        self.queue = asyncio.Queue()
 
     async def connect(self, websocket: WebSocket):
         await websocket.accept()
@@ -22,27 +24,40 @@ class ConnectionManager:
         await websocket.send_text(message)
 
     async def broadcast(self, message: str):
+        print("Connections", self.active_connections)
         for connection in self.active_connections:
+            print(connection, message)
             await connection.send_text(message)
 
 
 manager = ConnectionManager()
 
 
-@ws.websocket("/ws/{client_id}")
-async def manage_connection(websocket: WebSocket, client_id: str):
+@ws.websocket("/ws/test/{client_id}")
+async def websocket_endpoint(websocket: WebSocket, client_id: int):
+    await manager.connect(websocket)
+    await check_connections(manager.active_connections)
+    print(
+        f"active connection statuses: {[ac.client_state for ac in manager.active_connections]}"
+    )
+
+    await manager.broadcast(f"Client {client_id} joined")
     try:
-        await manager.connect(websocket)
+        while True:
+            await asyncio.sleep(5)
+            file = await manager.queue.get()
+            await manager.broadcast(f"Client #{client_id} uploaded file {file}")
     except WebSocketDisconnect:
         manager.disconnect(websocket)
-        await manager.broadcast(f"Client {client_id} disconnected")
-        print("Client disconnected")
+        await manager.broadcast(f"Client #{client_id} disconnected")
 
 
-async def update_clients(file_name):
-    print("CONNECTIONS", manager.active_connections)
-    try:
-        await manager.broadcast(f"File transferred {file_name}")
-    except WebSocketDisconnect:
-        await manager.broadcast("Client disconnected")
-        print("Client disconnected")
+async def check_connections(active_connections):
+    print("Checking connections")
+    for connection in active_connections:
+        print("Checking response")
+        try:
+            await asyncio.wait_for(connection.receive(), timeout=6)
+        except asyncio.TimeoutError:
+            print(f"Disconnecting client {connection}")
+            manager.disconnect(connection)

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -39,7 +39,8 @@ async def manage_connection(websocket: WebSocket, client_id: str):
         print("Client disconnected")
 
 
-def update_clients(file_name):
+async def update_clients(file_name):
+    print("CONNECTIONS", manager.active_connections)
     try:
         await manager.broadcast(f"File transferred {file_name}")
     except WebSocketDisconnect:

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -46,9 +46,10 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
     await manager.broadcast(f"Client {client_id} joined")
     try:
         while True:
-            await asyncio.sleep(5)
-            file = await manager.queue.get()
-            await manager.broadcast(f"Client #{client_id} uploaded file {file}")
+            # await asyncio.sleep(5)
+            # file = await manager.queue.get()
+            data = await websocket.receive_text()
+            await manager.broadcast(f"Client #{client_id} sent message {data}")
     except WebSocketDisconnect:
         print("Disconnecting", websocket, client_id)
         manager.disconnect(websocket, client_id)

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -26,9 +26,9 @@ class ConnectionManager:
         await websocket.send_text(message)
 
     async def broadcast(self, message: str):
-        print("Connections", self.active_connections)
+        # print("Connections", self.active_connections)
         for connection in self.active_connections:
-            print(connection, message)
+            # print(connection, message)
             await self.active_connections[connection].send_text(message)
 
 

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import List
+from typing import Dict
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
@@ -10,15 +10,17 @@ ws = APIRouter(prefix="/ws", tags=["websocket"])
 
 class ConnectionManager:
     def __init__(self):
-        self.active_connections: List[WebSocket] = []
+        self.active_connections: Dict[str, WebSocket] = {}
         self.queue = asyncio.Queue()
 
-    async def connect(self, websocket: WebSocket):
+    async def connect(self, websocket: WebSocket, client_id):
         await websocket.accept()
-        self.active_connections.append(websocket)
+        self.active_connections[client_id] = websocket
+        # self.active_connections.append(websocket)
 
-    def disconnect(self, websocket: WebSocket):
-        self.active_connections.remove(websocket)
+    def disconnect(self, websocket: WebSocket, client_id):
+        self.active_connections.pop(client_id)
+        # self.active_connections.remove(websocket)
 
     async def send_individual_message(self, message: str, websocket: WebSocket):
         await websocket.send_text(message)
@@ -27,7 +29,7 @@ class ConnectionManager:
         print("Connections", self.active_connections)
         for connection in self.active_connections:
             print(connection, message)
-            await connection.send_text(message)
+            await self.active_connections[connection].send_text(message)
 
 
 manager = ConnectionManager()
@@ -35,11 +37,11 @@ manager = ConnectionManager()
 
 @ws.websocket("/ws/test/{client_id}")
 async def websocket_endpoint(websocket: WebSocket, client_id: int):
-    await manager.connect(websocket)
-    await check_connections(manager.active_connections)
-    print(
-        f"active connection statuses: {[ac.client_state for ac in manager.active_connections]}"
-    )
+    await manager.connect(websocket, client_id)
+    # await check_connections(manager.active_connections)
+    # print(
+    #    f"active connection statuses: {[ac.client_state for ac in manager.active_connections]}"
+    # )
 
     await manager.broadcast(f"Client {client_id} joined")
     try:
@@ -48,7 +50,8 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
             file = await manager.queue.get()
             await manager.broadcast(f"Client #{client_id} uploaded file {file}")
     except WebSocketDisconnect:
-        manager.disconnect(websocket)
+        print("Disconnecting", websocket, client_id)
+        manager.disconnect(websocket, client_id)
         await manager.broadcast(f"Client #{client_id} disconnected")
 
 
@@ -60,4 +63,11 @@ async def check_connections(active_connections):
             await asyncio.wait_for(connection.receive(), timeout=6)
         except asyncio.TimeoutError:
             print(f"Disconnecting client {connection}")
-            manager.disconnect(connection)
+            manager.disconnect(connection[0], connection[1])
+
+
+@ws.delete("/ws/test/{client_id}")
+async def close_ws_connection(client_id):
+    print("Disconnecting", client_id)
+    manager.disconnect(manager.active_connections[client_id], client_id)
+    await manager.broadcast(f"Client #{client_id} disconnected")


### PR DESCRIPTION
Add updating functionality to websockets.
Server broadcasts to all connected clients when a new client joins, and when a post request is received.

To see this you can start a server (murfey.server), client (murfey) and send a post request eg. 
`curl -X POST http://127.0.0.1:8000/visits/cm31111-1/files --data '{"name": "microscope", "description": "8361", "size": 25, "timestamp": 24.0}' -H "Content-Type: application/json"`