### PR TITLE
Start Data Collection in ISPyB

### DIFF
--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -130,12 +130,14 @@ def run():
         start_time = str(datetime.datetime.now())
         image_directory = str(args.destination)
         image_suffix = input("Enter the image suffix: ")
+        visit = str(args.visit)
         dc_params = {
             "type": "start_dc",
             "params": {
                 "start_time": start_time,
                 "image_directory": image_directory,
                 "image_suffix": image_suffix,
+                "visit": visit,
             },
         }
         ws.send(json.dumps(dc_params))

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -133,12 +133,10 @@ def run():
         visit = str(args.visit)
         dc_params = {
             "type": "start_dc",
-            "params": {
-                "start_time": start_time,
-                "image_directory": image_directory,
-                "image_suffix": image_suffix,
-                "visit": visit,
-            },
+            "start_time": start_time,
+            "image_directory": image_directory,
+            "image_suffix": image_suffix,
+            "visit": visit,
         }
         ws.send(json.dumps(dc_params))
 

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -125,9 +125,6 @@ def run():
     ongoing_visits = _get_visit_list(murfey_url)
     pprint(ongoing_visits)
 
-    # current_visit = [visit for visit in ongoing_visits if visit.name == args.visit]
-    # session_id = current_visit[0].session_id
-
     _enable_webbrowser_in_cygwin()
 
     log.setLevel(logging.DEBUG)

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -123,7 +123,11 @@ def run():
     from pprint import pprint
 
     print("Ongoing visits:")
-    pprint(_get_visit_list(murfey_url))
+    ongoing_visits = _get_visit_list(murfey_url)
+    pprint(ongoing_visits)
+
+    current_visit = [visit for visit in ongoing_visits if visit.name == args.visit]
+    session_id = current_visit[0].session_id
 
     _enable_webbrowser_in_cygwin()
 
@@ -149,6 +153,7 @@ def run():
         dc_params = {
             "type": "start_dc",
             "start_time": start_time,
+            "session_id": session_id,
             "image_directory": image_directory,
             "image_suffix": image_suffix,
             "visit": visit,

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import argparse
 import configparser
-import datetime
 import json
 import logging
 import platform
@@ -126,8 +125,8 @@ def run():
     ongoing_visits = _get_visit_list(murfey_url)
     pprint(ongoing_visits)
 
-    current_visit = [visit for visit in ongoing_visits if visit.name == args.visit]
-    session_id = current_visit[0].session_id
+    # current_visit = [visit for visit in ongoing_visits if visit.name == args.visit]
+    # session_id = current_visit[0].session_id
 
     _enable_webbrowser_in_cygwin()
 
@@ -146,14 +145,11 @@ def run():
         "Press 'D' to start a new Data Collection or press any other key to continue:"
     )
     if start_dc == "D":
-        start_time = str(datetime.datetime.now())
         image_directory = str(args.destination)
         image_suffix = input("Enter the image suffix: ")
         visit = str(args.visit)
         dc_params = {
             "type": "start_dc",
-            "start_time": start_time,
-            "session_id": session_id,
             "image_directory": image_directory,
             "image_suffix": image_suffix,
             "visit": visit,

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import configparser
+import datetime
+import json
 import logging
 import platform
 import shutil
@@ -120,6 +122,23 @@ def run():
     logging.getLogger("websocket").setLevel(logging.WARNING)
 
     log.info("Starting Websocket connection")
+
+    start_dc = input(
+        "Press 'D' to start a new Data Collection or press any other key to continue:"
+    )
+    if start_dc == "D":
+        start_time = str(datetime.datetime.now())
+        image_directory = str(args.destination)
+        image_suffix = input("Enter the image suffix: ")
+        dc_params = {
+            "type": "start_dc",
+            "params": {
+                "start_time": start_time,
+                "image_directory": image_directory,
+                "image_suffix": image_suffix,
+            },
+        }
+        ws.send(json.dumps(dc_params))
 
     def rsync_result(update: murfey.client.rsync.RSyncerUpdate):
         if update.outcome is murfey.client.rsync.TransferResult.SUCCESS:

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -80,7 +80,6 @@ class LogFilter(logging.Filter):
 def run():
     # setup logging
     zc = zocalo.configuration.from_file()
-    # zc.activate_environment("devrmq")
     zc.activate()
 
     # Install a log filter to all existing handlers.
@@ -100,11 +99,6 @@ def run():
         type=int,
         default=8000,
     )
-    # parser.add_argument(
-    #    "--transport",
-    #    help="Transport type for Zocalo connection (default: Pika Transport)",
-    #    default="PikaTransport",
-    # )
 
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument(

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -11,7 +11,7 @@ import uvicorn
 import zocalo.configuration
 from fastapi.templating import Jinja2Templates
 from rich.logging import RichHandler
-import workflows.transport
+
 import murfey
 import murfey.server.ispyb
 
@@ -27,6 +27,8 @@ template_files = files("murfey") / "templates"
 templates = Jinja2Templates(directory=template_files)
 
 _running_server: uvicorn.Server | None = None
+_transport_object = None
+
 
 def respond_with_template(filename: str, parameters: dict[str, Any] | None = None):
     template_parameters = {
@@ -96,7 +98,11 @@ def run():
         type=int,
         default=8000,
     )
-    parser.add_argument("--transport", help="Transport type for Zocalo connection (default: Pika Transport)", default="PikaTransport")
+    parser.add_argument(
+        "--transport",
+        help="Transport type for Zocalo connection (default: Pika Transport)",
+        default="PikaTransport",
+    )
 
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument(
@@ -216,5 +222,7 @@ def _set_up_logging(quiet: bool, verbosity: int):
     for logger_name, log_level in log_levels.items():
         logging.getLogger(logger_name).setLevel(log_level)
 
+
 def _set_up_transport(transport_type):
-    murfey.server.ispyb.TransportManager(transport_type)
+    global _transport_object
+    _transport_object = murfey.server.ispyb.TransportManager(transport_type)

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -8,6 +8,7 @@ import socket
 from typing import Any
 
 import uvicorn
+import workflows
 import zocalo.configuration
 from fastapi.templating import Jinja2Templates
 from rich.logging import RichHandler
@@ -79,7 +80,8 @@ class LogFilter(logging.Filter):
 def run():
     # setup logging
     zc = zocalo.configuration.from_file()
-    zc.activate_environment("devrmq")
+    # zc.activate_environment("devrmq")
+    zc.activate()
 
     # Install a log filter to all existing handlers.
     # At this stage this will exclude console loggers, but will cover
@@ -98,11 +100,11 @@ def run():
         type=int,
         default=8000,
     )
-    parser.add_argument(
-        "--transport",
-        help="Transport type for Zocalo connection (default: Pika Transport)",
-        default="PikaTransport",
-    )
+    # parser.add_argument(
+    #    "--transport",
+    #    help="Transport type for Zocalo connection (default: Pika Transport)",
+    #    default="PikaTransport",
+    # )
 
     verbosity = parser.add_mutually_exclusive_group()
     verbosity.add_argument(
@@ -119,6 +121,9 @@ def run():
         help="Increase logging output verbosity",
         default=0,
     )
+    zc.add_command_line_options(parser)
+    workflows.transport.add_command_line_options(parser, transport_argument=True)
+
     args = parser.parse_args()
 
     # Set up Zocalo connection

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -29,7 +29,9 @@ class TransportManager:
         self.transport.connect()
 
     def start_dc(self, message):
-        self.transport.send("ispyb_connector", message)
+        message["ispyb_command"] = "insert_data_collection"
+        ispyb_message = {"content": "Murfey DC insert", "parameters": message}
+        self.transport.send("ispyb_connector", ispyb_message)
 
 
 def _get_session() -> sqlalchemy.orm.Session:

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -38,12 +38,6 @@ class TransportManager:
             "processing_recipe", {"recipes": ["ispyb-murfey"], "parameters": message}
         )
 
-    def insert_data_collection_group(self, message):
-        message["ispyb_command"] = "insert_data_collection_group"
-        ispyb_message = {"content": "Murfey DCG insert", "parameters": message}
-        self.transport.send("ispyb_connector", ispyb_message)
-        return
-
 
 def _get_session() -> sqlalchemy.orm.Session:
     db = Session()

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -8,6 +8,7 @@ import sqlalchemy.orm
 import workflows.transport
 from fastapi import Depends
 
+import murfey.server
 from murfey.util.models import Visit
 
 # from sqlalchemy.orm import Load
@@ -34,6 +35,13 @@ class TransportManager:
         self.transport.connect()
 
     def start_dc(self, message):
+        message["start_time"] = str(datetime.datetime.now())
+        visits = get_all_ongoing_visits(murfey.server.get_microscope(), Session())
+        current_visit_object = [
+            visit for visit in visits if visit.name == message["visit"]
+        ]
+        if current_visit_object:
+            message["session_id"] = current_visit_object[0].session_id
         self.transport.send(
             "processing_recipe", {"recipes": ["ispyb-murfey"], "parameters": message}
         )

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -11,9 +11,6 @@ from fastapi import Depends
 import murfey.server
 from murfey.util.models import Visit
 
-# from sqlalchemy.orm import Load
-
-
 _BLSession = ispyb.sqlalchemy.BLSession
 _Proposal = ispyb.sqlalchemy.Proposal
 _DataCollection = ispyb.sqlalchemy.DataCollection

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import datetime
 import logging
-import time
 
 import ispyb.sqlalchemy
 import sqlalchemy.orm
@@ -35,16 +34,9 @@ class TransportManager:
         self.transport.connect()
 
     def start_dc(self, message):
-        first_dcgid_list = get_data_collection_group_ids(message["session_id"])
-        self.insert_data_collection_group(message)
-        time.sleep(1)
-        second_dcgid_list = get_data_collection_group_ids(message["session_id"])
-        dcgid = list(set(second_dcgid_list) - set(first_dcgid_list))
-
-        message["ispyb_command"] = "insert_data_collection"
-        message["dcgid"] = dcgid[0]
-        ispyb_message = {"content": "Murfey DC insert", "parameters": message}
-        self.transport.send("ispyb_connector", ispyb_message)
+        self.transport.send(
+            "processing_recipe", {"recipes": ["ispyb-murfey"], "parameters": message}
+        )
 
     def insert_data_collection_group(self, message):
         message["ispyb_command"] = "insert_data_collection_group"

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -10,7 +10,8 @@ from fastapi import Depends
 
 _BLSession = ispyb.sqlalchemy.BLSession
 _Proposal = ispyb.sqlalchemy.Proposal
-
+_DataCollection = ispyb.sqlalchemy.DataCollection
+_ProcessingJob = ispyb.sqlalchemy.ProcessingJob
 
 log = logging.getLogger("murfey.server.ispyb")
 
@@ -83,3 +84,12 @@ def get_all_ongoing_visits(microscope: str, db: sqlalchemy.orm.Session) -> list[
         )
         for row in query
     ]
+
+def start_data_collection(db: sqlalchemy.orm.Session):
+    comment = "Test Murfey DC insert"
+    insert = _DataCollection(comments=comment)
+    #insert = _ProcessingJob(comments=comment)
+    db.add(insert)
+    db.commit()
+
+#start_data_collection(Session())

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 
 import ispyb.sqlalchemy
 import sqlalchemy.orm
-from fastapi import Depends
 import workflows.transport
+from fastapi import Depends
 
 _BLSession = ispyb.sqlalchemy.BLSession
 _Proposal = ispyb.sqlalchemy.Proposal
@@ -22,11 +22,15 @@ Session = sqlalchemy.orm.sessionmaker(
     )
 )
 
-class TransportManager():
+
+class TransportManager:
     def __init__(self, transport_type):
-        transport = workflows.transport.lookup(transport_type)()
-        transport.connect()
-        transport.send("ispyb_connector", "ispyb_command_list")
+        self.transport = workflows.transport.lookup(transport_type)()
+        self.transport.connect()
+
+    def start_dc(self, message):
+        self.transport.send("ispyb_connector", message)
+
 
 def _get_session() -> sqlalchemy.orm.Session:
     db = Session()
@@ -91,11 +95,13 @@ def get_all_ongoing_visits(microscope: str, db: sqlalchemy.orm.Session) -> list[
         for row in query
     ]
 
+
 def start_data_collection(db: sqlalchemy.orm.Session):
     comment = "Test Murfey DC insert"
     insert = _DataCollection(comments=comment)
-    #insert = _ProcessingJob(comments=comment)
+    # insert = _ProcessingJob(comments=comment)
     db.add(insert)
     db.commit()
 
-#start_data_collection(Session())
+
+# start_data_collection(Session())

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import ispyb.sqlalchemy
 import sqlalchemy.orm
 from fastapi import Depends
+import workflows.transport
 
 _BLSession = ispyb.sqlalchemy.BLSession
 _Proposal = ispyb.sqlalchemy.Proposal
@@ -21,6 +22,11 @@ Session = sqlalchemy.orm.sessionmaker(
     )
 )
 
+class TransportManager():
+    def __init__(self, transport_type):
+        transport = workflows.transport.lookup(transport_type)()
+        transport.connect()
+        transport.send("ispyb_connector", "ispyb_command_list")
 
 def _get_session() -> sqlalchemy.orm.Session:
     db = Session()

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -9,6 +9,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from ispyb.sqlalchemy import BLSession, Proposal
 from pydantic import BaseModel
+import workflows.transport
 
 import murfey.server
 import murfey.server.bootstrap

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -9,7 +9,6 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from ispyb.sqlalchemy import BLSession, Proposal
 from pydantic import BaseModel
-import workflows.transport
 
 import murfey.server
 import murfey.server.bootstrap

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -64,6 +64,7 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
                     json_data.pop("type")
                     await forward_log(json_data)
                 elif json_data["type"] == "start_dc":
+                    json_data.pop("type")
                     await start_dc(json_data)
             except Exception:
                 await manager.broadcast(f"Client #{client_id} sent message {data}")

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -65,7 +65,8 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
                     await forward_log(json_data)
                 elif json_data["type"] == "start_dc":
                     json_data.pop("type")
-                    await start_dc(json_data)
+                    assert _transport_object is not None
+                    await _transport_object.start_dc(json_data)
             except Exception:
                 await manager.broadcast(f"Client #{client_id} sent message {data}")
     except WebSocketDisconnect:
@@ -89,10 +90,6 @@ async def check_connections(active_connections):
 async def forward_log(logrecord):
     record_name = logrecord["name"]
     logging.getLogger(record_name).handle(logging.makeLogRecord(logrecord))
-
-
-async def start_dc(data):
-    _transport_object.start_dc(data)
 
 
 @ws.delete("/ws/test/{client_id}")

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -7,6 +7,7 @@ from typing import Dict, Generic, TypeVar
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
+from murfey.server import _transport_object
 from murfey.util.state import State, global_state
 
 T = TypeVar("T")
@@ -62,6 +63,8 @@ async def websocket_endpoint(websocket: WebSocket, client_id: int):
                 if json_data["type"] == "log":  # and isinstance(json_data, dict)
                     json_data.pop("type")
                     await forward_log(json_data)
+                elif json_data["type"] == "start_dc":
+                    await start_dc(json_data)
             except Exception:
                 await manager.broadcast(f"Client #{client_id} sent message {data}")
     except WebSocketDisconnect:
@@ -85,6 +88,10 @@ async def check_connections(active_connections):
 async def forward_log(logrecord):
     record_name = logrecord["name"]
     logging.getLogger(record_name).handle(logging.makeLogRecord(logrecord))
+
+
+async def start_dc(data):
+    _transport_object.start_dc(data)
 
 
 @ws.delete("/ws/test/{client_id}")

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 class Visit(BaseModel):
     start: datetime
     end: datetime
+    session_id: int
     name: str
     beamline: str
     proposal_title: str
@@ -17,6 +18,7 @@ class Visit(BaseModel):
             "Visit("
             f"start='{self.start:%Y-%m-%d %H:%M}', "
             f"end='{self.end:%Y-%m-%d %H:%M}', "
+            f"session_id='{self.session_id!r}',"
             f"name={self.name!r}, "
             f"beamline={self.beamline!r}, "
             f"proposal_title={self.proposal_title!r}"


### PR DESCRIPTION
Note: as of this PR the server must be started with "murfey.server -e devrmq -t PikaTransport" rather than just "murfey.server" because the dev environment is no longer hardcoded.

Send messages via Zocalo to start a Data Collection.
Uses the visit given when the Murfey client is started and looks up session_id with SQLAlchemy.
Some fields in the DC entry are filled in.