### PR TITLE
Add basic setup to allow reading of machine configuration files

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ pydantic==1.9.0
 pytest-cov==3.0.0
 pytest==7.1.2
 pyyaml==6.0
-rich==12.4.1
+rich==12.4.4
 textual==0.1.18
 uvicorn[standard]==0.17.6
 websocket-client==1.3.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ procrunner==2.3.3
 pydantic==1.9.0
 pytest-cov==3.0.0
 pytest==7.1.2
+pyyaml==6.0
 rich==12.4.1
 textual==0.1.18
 uvicorn[standard]==0.17.6

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -17,7 +17,7 @@ import murfey
 import murfey.server.ispyb
 
 try:
-    from importlib.resources import files
+    from importlib.resources import files  # type: ignore
 except ImportError:
     # Fallback for Python 3.8
     from importlib_resources import files  # type: ignore

--- a/src/murfey/server/config.py
+++ b/src/murfey/server/config.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Union
+
+import yaml
+from pydantic import BaseModel
+
+
+class MachineConfig(BaseModel):
+    name: str
+    acquisition_software: List[str]
+    calibrations: Dict[str, Union[dict, float]]
+
+
+def from_file(config_file_path: Path) -> MachineConfig:
+    with open(config_file_path, "r") as config_stream:
+        config = yaml.safe_load(config_stream)
+    return MachineConfig(**config)

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -26,7 +26,7 @@ tags_metadata = [murfey.server.bootstrap.tag]
 
 
 class Settings(BaseSettings):
-    murfey_machine_configuration: str
+    murfey_machine_configuration: str = ""
 
 
 settings = Settings()
@@ -58,7 +58,9 @@ async def root(request: Request):
 @lru_cache(maxsize=1)
 @app.get("/machine/")
 def machine_info():
-    return from_file(settings.murfey_machine_configuration)
+    if settings.murfey_machine_configuration:
+        return from_file(settings.murfey_machine_configuration)
+    return {}
 
 
 @app.get("/visits/")


### PR DESCRIPTION
This will allow microscope specific information such as calibrated pixel sizes to be stored in a location accessible to the server and looked up when required for processing parameters. Environment variable `MURFEY_MACHINE_CONFIGURATION` used to point to config file