### PR TITLE
Determine acquisition software and perform tasks accordingly

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import logging
+import queue
+import threading
+from pathlib import Path
+from typing import Optional
+
+from murfey.client.context import Context, SPAContext, TomographyContext
+from murfey.util import Observer
+
+logger = logging.getLogger("murfey.client.analyser")
+
+
+class Analyser(Observer):
+    def __init__(self):
+        super().__init__()
+        self._experiment_type = ""
+        self._acquisition_software = ""
+        self._context: Context | None = None
+        self._batch_store = {}
+
+        self.queue = queue.Queue[Optional[Path]]()
+        self.thread = threading.Thread(name="Analyser", target=self._analyse)
+        self._stopping = False
+        self._halt_thread = False
+
+    def _find_context(self, file_path: Path) -> bool:
+        split_file_name = file_path.name.split("_")
+        if split_file_name:
+            if split_file_name[0] == "Position":
+                self._context = TomographyContext("tomo")
+                return True
+            if split_file_name[0].startswith("FoilHole"):
+                self._context = SPAContext("epu")
+                return True
+        return False
+
+    def _analyse(self):
+        while not self._halt_thread:
+            transferred_file = self.queue.get()
+            if not self._experiment_type or not self._acquisition_software:
+                found = self._find_context(transferred_file)
+                if not found:
+                    logger.warning(
+                        f"Context not understood for {transferred_file}, stopping analysis"
+                    )
+                    self.stop()
+            else:
+                self._context.post_transfer(transferred_file)
+
+    def stop(self):
+        logger.debug("Analyser thread stop requested")
+        self._stopping = True
+        self._halt_thread = True
+        if self.thread.is_alive():
+            self.queue.put(None)
+            self.thread.join()
+        logger.debug("Analyser thread stop completed")

--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -46,6 +46,8 @@ class Analyser(Observer):
                         f"Context not understood for {transferred_file}, stopping analysis"
                     )
                     self.stop()
+                else:
+                    self._context.post_first_transfer(transferred_file)
             else:
                 self._context.post_transfer(transferred_file)
 

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -54,13 +54,16 @@ class TomographyContext(Context):
             last_tilt_angle = self._last_transferred_file.name.split("[")[1].split("]")[
                 0
             ]
+            self._last_transferred_file = file_path
             if last_tilt_series != tilt_series and last_tilt_angle != tilt_angle:
                 newly_completed_series = []
-                tilt_series_size = max(len(ts) for ts in self._tilt_series.values())
+                if self._tilt_series:
+                    tilt_series_size = max(len(ts) for ts in self._tilt_series.values())
+                else:
+                    tilt_series_size = 0
                 this_tilt_series_size = len(self._tilt_series[tilt_series])
                 if this_tilt_series_size >= tilt_series_size:
                     self._completed_tilt_series.append(tilt_series)
-                    self._last_transferred_file = file_path
                     newly_completed_series.append(tilt_series)
                 for ts, ta in self._tilt_series.items():
                     if (

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, List
+
+logger = logging.getLogger("murfey.client.context")
+
+
+class Context:
+    def __init__(self, acquisition_software: str):
+        self._acquisition_software = acquisition_software
+
+    def post_transfer(self, transferred_file: Path):
+        raise NotImplementedError
+
+    def gather_metadata(self):
+        raise NotImplementedError
+
+
+class SPAContext(Context):
+    def post_transfer(self, transferred_file: Path):
+        pass
+
+
+class TomographyContext(Context):
+    def __init__(self, acquisition_software: str):
+        super().__init__(acquisition_software)
+        self._tilt_series: Dict[str, List[Path]] = {}
+        self._completed_tilt_series: List[str] = []
+        self._last_transferred_file: Path | None = None
+
+    def _add_tomo_tilt(self, file_path: Path) -> List[str]:
+        tilt_series = file_path.name.split("_")[1]
+        tilt_angle = file_path.name.split("[")[1].split("]")[0]
+        if tilt_series in self._completed_tilt_series:
+            logger.info(
+                f"Tilt series {tilt_series} was previously thought complete but now {file_path} has been seen"
+            )
+            self._completed_tilt_series.remove(tilt_series)
+        if not self._tilt_series.get(tilt_series):
+            self._tilt_series[tilt_series] = [file_path]
+        else:
+            self._tilt_series[tilt_series].append(file_path)
+        if self._last_transferred_file:
+            last_tilt_series = self._last_transferred_file.name.split("_")[1]
+            last_tilt_angle = self._last_transferred_file.name.split("[")[1].split("]")[
+                0
+            ]
+            if last_tilt_series != tilt_series and last_tilt_angle != tilt_angle:
+                self._completed_tilt_series.append(tilt_series)
+                self._last_transferred_file = file_path
+                tilt_series_size = len(self._tilt_series[tilt_series])
+                newly_completed_series = [tilt_series]
+                for ts, ta in self._tilt_series.items():
+                    if (
+                        len(ta) >= tilt_series_size
+                        and ts not in self._completed_tilt_series
+                    ):
+                        newly_completed_series.append(ts)
+                logger.info(
+                    f"The following tilt series are considered complete: {newly_completed_series}"
+                )
+                return newly_completed_series
+        self._last_transferred_file = file_path
+        return []
+
+    def post_transfer(self, transferred_file: Path) -> List[str]:
+        completed_tilts = []
+        if self._acquisition_software == "tomo":
+            completed_tilts = self._add_tomo_tilt(transferred_file)
+        return completed_tilts

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -12,10 +12,17 @@ class Context:
         self._acquisition_software = acquisition_software
 
     def post_transfer(self, transferred_file: Path):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"post_transfer hook must be declared in derived class to be used: {self}"
+        )
+
+    def post_first_transfer(self, transferred_file: Path):
+        self.post_transfer(transferred_file)
 
     def gather_metadata(self):
-        raise NotImplementedError
+        raise NotImplementedError(
+            f"gather_metadata must be declared in derived class to be used: {self}"
+        )
 
 
 class SPAContext(Context):

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -55,16 +55,20 @@ class TomographyContext(Context):
                 0
             ]
             if last_tilt_series != tilt_series and last_tilt_angle != tilt_angle:
-                self._completed_tilt_series.append(tilt_series)
-                self._last_transferred_file = file_path
-                tilt_series_size = len(self._tilt_series[tilt_series])
-                newly_completed_series = [tilt_series]
+                newly_completed_series = []
+                tilt_series_size = max(len(ts) for ts in self._tilt_series.values())
+                this_tilt_series_size = len(self._tilt_series[tilt_series])
+                if this_tilt_series_size >= tilt_series_size:
+                    self._completed_tilt_series.append(tilt_series)
+                    self._last_transferred_file = file_path
+                    newly_completed_series.append(tilt_series)
                 for ts, ta in self._tilt_series.items():
                     if (
                         len(ta) >= tilt_series_size
                         and ts not in self._completed_tilt_series
                     ):
                         newly_completed_series.append(ts)
+                        self._completed_tilt_series.append(ts)
                 logger.info(
                     f"The following tilt series are considered complete: {newly_completed_series}"
                 )

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -175,7 +175,7 @@ class ProcessFile(BaseModel):
 @app.post("/visits/{visit_name}/common_preprocess")
 async def request_common_preprocessing(proc_file: ProcessFile):
     zocalo_message = {
-        "recipes": ["relion"],
+        "recipes": ["em_common_preprocess"],
         "parameters": {
             "ispyb_process": proc_file.processing_job,
             "movie": proc_file.name,
@@ -191,6 +191,35 @@ async def request_common_preprocessing(proc_file: ProcessFile):
         return proc_file
     await ws.manager.broadcast(f"Processing requested for {proc_file.name}")
     return proc_file
+
+
+class TiltSeries(BaseModel):
+    name: str
+    tilts: List[str]
+    processing_job: int
+
+
+@app.post("/visits/{visit_name}/align")
+async def request_tilt_series_alignment(tilt_series: TiltSeries):
+    zocalo_message = {
+        "recipes": ["em_align"],
+        "parameters": {
+            "ispyb_process": tilt_series.processing_job,
+            "tilts": tilt_series.tilts,
+        },
+    }
+    log.info(f"Sending Zocalo message {zocalo_message}")
+    if _transport_object:
+        _transport_object.transport.send("processing_recipe", zocalo_message)
+    else:
+        log.error(
+            f"Processing was requested for tilt series {tilt_series.name} but no Zocalo transport object was found"
+        )
+        return tilt_series
+    await ws.manager.broadcast(
+        f"Processing requested for tilt series {tilt_series.name}"
+    )
+    return tilt_series
 
 
 @app.get("/version")

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -17,7 +17,13 @@ import murfey.server.bootstrap
 import murfey.server.ispyb
 import murfey.server.websocket as ws
 import murfey.util.models
-from murfey.server import get_hostname, get_microscope, template_files, templates
+from murfey.server import (
+    _transport_object,
+    get_hostname,
+    get_microscope,
+    template_files,
+    templates,
+)
 from murfey.server.config import from_file
 
 log = logging.getLogger("murfey.server.main")
@@ -156,6 +162,35 @@ async def add_file(file: File):
     log.info(message)
     await ws.manager.broadcast(f"File {file} transferred")
     return file
+
+
+class ProcessFile(BaseModel):
+    name: str
+    description: str
+    size: int
+    timestamp: float
+    processing_job: int
+
+
+@app.post("/visits/{visit_name}/common_preprocess")
+async def request_common_preprocessing(proc_file: ProcessFile):
+    zocalo_message = {
+        "recipes": ["relion"],
+        "parameters": {
+            "ispyb_process": proc_file.processing_job,
+            "movie": proc_file.name,
+        },
+    }
+    log.info(f"Sending Zocalo message {zocalo_message}")
+    if _transport_object:
+        _transport_object.transport.send("processing_recipe", zocalo_message)
+    else:
+        log.error(
+            f"Processing was requested for {proc_file.name} but no Zocalo transport object was found"
+        )
+        return proc_file
+    await ws.manager.broadcast(f"Processing requested for {proc_file.name}")
+    return proc_file
 
 
 @app.get("/version")

--- a/tests/client/test.py
+++ b/tests/client/test.py
@@ -10,5 +10,5 @@ import murfey.client.main as main
 
 @pytest.mark.xfail
 def test_get_visit_info():
-    response = main.get_visit_info("cm31111-1")  # Should be valid until end of 2021
+    response = main.get_visit_info("cm31111-1")  # Should be valid until end of 2022
     assert response.status_code == 200

--- a/tests/client/test_analyser.py
+++ b/tests/client/test_analyser.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from murfey.client.analyser import Analyser
+
+
+def test_analyser_setup_and_stopping():
+    analyser = Analyser()
+    assert analyser.queue.empty()
+    analyser.start()
+    assert analyser.thread.is_alive()
+    analyser.stop()
+    assert analyser._halt_thread
+    assert not analyser.thread.is_alive()
+
+
+def test_analyser_tomo_determination(tmp_path):
+    tomo_file = tmp_path / "Position_1_[30.0].tiff"
+    analyser = Analyser()
+    analyser.start()
+    analyser.queue.put(tomo_file)
+    analyser.stop()
+    assert analyser._context._acquisition_software == "tomo"
+
+
+def test_analyser_epu_determination(tmp_path):
+    tomo_file = tmp_path / "FoilHole_12345_Data_6789.tiff"
+    analyser = Analyser()
+    analyser.start()
+    analyser.queue.put(tomo_file)
+    analyser.stop()
+    assert analyser._context._acquisition_software == "epu"

--- a/tests/client/test_context.py
+++ b/tests/client/test_context.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from murfey.client.context import TomographyContext
+
+
+def test_tomography_context_initialisation_for_tomo():
+    context = TomographyContext("tomo")
+    assert not context._last_transferred_file
+    assert context._acquisition_software == "tomo"
+
+
+def test_tomography_context_add_tomo_tilt(tmp_path):
+    context = TomographyContext("tomo")
+    context.post_transfer(tmp_path / "Position_1_[30.0].tiff")
+    assert context._tilt_series == {"1": [tmp_path / "Position_1_[30.0].tiff"]}
+    assert context._last_transferred_file == tmp_path / "Position_1_[30.0].tiff"
+    context.post_transfer(tmp_path / "Position_1_[-30.0].tiff")
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "Position_2_[30.0].tiff")
+    assert len(context._tilt_series.values()) == 2
+    assert context._completed_tilt_series == ["1"]
+
+
+def test_tomography_context_add_tomo_tilt_out_of_order(tmp_path):
+    context = TomographyContext("tomo")
+    context.post_transfer(tmp_path / "Position_1_[30.0].tiff")
+    assert context._tilt_series == {"1": [tmp_path / "Position_1_[30.0].tiff"]}
+    assert context._last_transferred_file == tmp_path / "Position_1_[30.0].tiff"
+    context.post_transfer(tmp_path / "Position_1_[-30.0].tiff")
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "Position_2_[-30.0].tiff")
+    assert len(context._tilt_series.values()) == 2
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "Position_2_[30.0].tiff")
+    assert len(context._tilt_series.values()) == 2
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "Position_3_[-30.0].tiff")
+    assert len(context._tilt_series.values()) == 3
+    assert context._completed_tilt_series == ["1", "2"]
+    context.post_transfer(tmp_path / "Position_3_[30.0].tiff")
+    assert context._completed_tilt_series == ["1", "2"]

--- a/tests/client/test_context.py
+++ b/tests/client/test_context.py
@@ -39,3 +39,19 @@ def test_tomography_context_add_tomo_tilt_out_of_order(tmp_path):
     assert context._completed_tilt_series == ["1", "2"]
     context.post_transfer(tmp_path / "Position_3_[30.0].tiff")
     assert context._completed_tilt_series == ["1", "2"]
+
+
+def test_tomography_context_add_tomo_tilt_delayed_tilt(tmp_path):
+    context = TomographyContext("tomo")
+    context.post_transfer(tmp_path / "Position_1_[30.0].tiff")
+    assert context._tilt_series == {"1": [tmp_path / "Position_1_[30.0].tiff"]}
+    assert context._last_transferred_file == tmp_path / "Position_1_[30.0].tiff"
+    context.post_transfer(tmp_path / "Position_1_[-30.0].tiff")
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "Position_2_[30.0].tiff")
+    assert len(context._tilt_series.values()) == 2
+    assert context._completed_tilt_series == ["1"]
+    context.post_transfer(tmp_path / "Position_2_[-30.0].tiff")
+    new_series = context.post_transfer(tmp_path / "Position_1_[60.0].tiff")
+    assert context._completed_tilt_series == ["1"]
+    assert new_series == ["1"]


### PR DESCRIPTION
Adds mechanisms for determining the acquisition software from the names of transferred files and then perform actions on every transfer. So far only actions for `Tomography 5` are implemented. This will allow processing to be performed based on which files have been transferred. This also contains the logic to determine when tilt series have been completed in both configurations where one tilt series is collected at once and where beam shift is used to collect multiple positions at each angle before collecting at the next angle. It should also cover the case where the files are transferred out of order, although less efficiently.