### PR TITLE
Handle ISPyB ID requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+mysql-connector-python<=0.8.29
 fastapi==0.78.0
 importlib_resources==5.8.0; python_version<'3.9'
 ispyb==6.11.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,6 +3,7 @@ fastapi==0.78.0
 importlib_resources==5.8.0; python_version<'3.9'
 ispyb==6.11.0
 jinja2==3.1.2
+mdocfile==0.0.6
 procrunner==2.3.3
 pydantic==1.9.1
 pytest-cov==3.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-mysql-connector-python<=0.8.29
+mysql-connector-python<=8.0.29
 fastapi==0.78.0
 importlib_resources==5.8.0; python_version<'3.9'
 ispyb==6.11.0

--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -188,7 +188,7 @@ def run():
     main_loop_thread.start()
 
     instance_environment = MurfeyInstanceEnvironment(
-        murfey_url,
+        url=murfey_url,
         source=Path(args.source),
         watcher=source_watcher,
         default_destination=args.destination,

--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -94,7 +94,7 @@ class Analyser(Observer):
                         try:
                             dc_metadata = self._context.gather_metadata(
                                 transferred_file.with_suffix(".mdoc")
-                                if self._context.acquisition_software == "serialem"
+                                if self._context._acquisition_software == "serialem"
                                 else transferred_file.with_suffix(".xml")
                             )
                         except NotImplementedError:

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -253,7 +253,7 @@ class TomographyContext(Context):
         return self._add_tilt(
             file_path,
             _extract_tilt_series,
-            lambda x: x.name.split(delimiter)[-1].split(".")[0],
+            lambda x: ".".join(x.name.split(delimiter)[-1].split(".")[:-1]),
             environment=environment,
         )
 

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -60,8 +60,9 @@ class TomographyContext(Context):
 
     def _flush_data_collections(self):
         for dc_data in self._data_collection_stash:
-            logger.debug(f"Sending data: {dc_data[1]}")
-            requests.post(dc_data[0], json=dc_data[1])
+            data = {**dc_data[2], **dc_data[1]._data_collection_parameters}
+            logger.debug(f"Sending data: {data}")
+            requests.post(dc_data[0], json=data)
         self._data_collection_stash = []
 
     def _flush_processing_job(self, tag: str):
@@ -95,11 +96,7 @@ class TomographyContext(Context):
                 if environment:  # and environment._processing_jobs.get(tilt_series):
                     url = f"{str(environment.murfey_url.geturl())}/visits/{environment.visit}/start_data_collection"
                     data = {
-                        "voltage": 300.0,
-                        "pixel_size_on_image": 1,
                         "experiment_type": "tomography",
-                        "image_size_x": 4026,
-                        "image_size_y": 4026,
                         "tilt": tilt_series,
                         "file_extension": file_path.suffix,
                         "acquisition_software": self._acquisition_software,
@@ -107,7 +104,7 @@ class TomographyContext(Context):
                         "tag": tilt_series,
                     }
                     if environment.data_collection_group_id is None:
-                        self._data_collection_stash.append((url, data))
+                        self._data_collection_stash.append((url, environment, data))
                     else:
                         logger.debug(f"Sending data: {data}")
                         requests.post(url, json=data)

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from murfey.client.instance_environment import (
     MovieID,
+    MovieTracker,
     MurfeyID,
     MurfeyInstanceEnvironment,
 )
@@ -132,9 +133,11 @@ class TomographyContext(Context):
         environment: MurfeyInstanceEnvironment | None = None,
     ) -> List[str]:
         if environment:
-            environment.movie_ids[file_path] = next(MurfeyID)
-            environment.motion_correction_ids[file_path] = next(MurfeyID)
-            environment.movie_numbers[file_path] = next(MovieID)
+            environment.movies[file_path] = MovieTracker(
+                movie_number=next(MovieID),
+                movie_uuid=next(MurfeyID),
+                motion_correction_uuid=next(MurfeyID),
+            )
         tilt_series = extract_tilt_series(file_path)
         tilt_angle = extract_tilt_angle(file_path)
         if tilt_series in self._completed_tilt_series:
@@ -171,9 +174,9 @@ class TomographyContext(Context):
                     preproc_url = f"{str(environment.murfey_url.geturl())}/visits/{environment.visit}/tomography_preprocess"
                     pfi = ProcessFileIncomplete(
                         path=file_path,
-                        image_number=environment.movie_numbers[file_path],
-                        movie_uuid=environment.movie_ids[file_path],
-                        mc_uuid=environment.motion_correction_ids[file_path],
+                        image_number=environment.movies[file_path].movie_number,
+                        movie_uuid=environment.movies[file_path].movie_uuid,
+                        mc_uuid=environment.movies[file_path].motion_correction_uuid,
                         tag=tilt_series,
                     )
                     if (

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from itertools import count
 from pathlib import Path
-from typing import Callable, Dict, NamedTuple, Set
+from typing import Callable, Dict, NamedTuple, Optional, Set
 from urllib.parse import ParseResult
 
 from pydantic import BaseModel, validator
@@ -24,14 +24,15 @@ class MovieTracker(NamedTuple):
 
 class MurfeyInstanceEnvironment(BaseModel):
     url: ParseResult
-    source: Path | None = None
+    source: Optional[Path] = None
     default_destination: str = ""
-    watcher: DirWatcher | None = None
+    watcher: Optional[DirWatcher] = None
     demo: bool = False
-    data_collection_group_id: int | None = None
+    data_collection_group_id: Optional[int] = None
     data_collection_ids: Dict[str, int] = {}
     processing_job_ids: Dict[str, int] = {}
     autoproc_program_ids: Dict[str, int] = {}
+    data_collection_parameters: dict = {}
     movies: Dict[Path, MovieTracker] = {}
     listeners: Dict[str, Set[Callable]] = {}
     visit: str = ""

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -64,17 +64,3 @@ class MurfeyInstanceEnvironment(BaseModel):
             else:
                 for k in v.keys():
                     l(k)
-
-    # def subscribe(self, callback: Callable):
-    #     self._listeners.append(callback)
-
-    # def subscribe_dcg(self, callback: Callable):
-    #     self._dcg_listeners.append(callback)
-
-    # def subscribe_dc(self, callback: Callable):
-    #     self._dc_listeners.append(callback)
-
-    # def new_processing_id(self, pid: int, tag: str):
-    #     self._processing_jobs[tag] = pid
-    #     for l in self._listeners:
-    #         l(tag)

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -1,22 +1,20 @@
 from __future__ import annotations
 
+import logging
+from itertools import count
 from pathlib import Path
 from typing import Any, Callable, Dict, List
 from urllib.parse import ParseResult
 
 from murfey.client.watchdir import DirWatcher
 
+logger = logging.getLogger("murfey.client.instance_environment")
+
+MurfeyID = count(1)
+MovieID = count(1)
+
 
 class MurfeyInstanceEnvironment:
-    # murfey_url: ParseResult
-    # source: Path | None = None
-    # default_destination: str = ""
-    # watcher: DirWatcher | None = None
-    # demo: bool = False
-    # data_collection_group_id: int | None = None
-    # visit: str = ""
-    # processing_jobs: dict[str, int] = {}
-
     def __init__(
         self,
         murfey_url: ParseResult,
@@ -37,9 +35,13 @@ class MurfeyInstanceEnvironment:
         self._listeners: List[Callable] = []
         self._dcg_listeners: List[Callable] = []
         self._dc_listeners: List[Callable] = []
+        self._autoproc_programs: Dict[str, int] = {}
         self._processing_jobs: Dict[str, int] = {}
         self._data_collections: Dict[str, int] = {}
         self._data_collection_parameters: Dict[str, Any] = {}
+        self.movie_ids: Dict[Path, int] = {}
+        self.motion_correction_ids: Dict[Path, int] = {}
+        self.movie_numbers: Dict[Path, int] = {}
 
     def subscribe(self, callback: Callable):
         self._listeners.append(callback)
@@ -65,3 +67,12 @@ class MurfeyInstanceEnvironment:
             self._data_collections[tag] = dcid
             for l in self._dc_listeners:
                 l(tag)
+
+    def register_app(self, appid: int, tag: str):
+        if tag not in list(self._autoproc_programs):
+            self._autoproc_programs[tag] = appid
+            logger.debug(f"APPID registered: {tag}: {self._listeners}")
+            for l in self._listeners:
+                logger.debug(f"calling {l} with {tag}")
+                l(tag)
+                logger.debug(f"called {l} with {tag}")

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -35,12 +35,32 @@ class MurfeyInstanceEnvironment:
         self.data_collection_group_id = data_collection_group_id
         self.visit = visit
         self._listeners: List[Callable] = []
+        self._dcg_listeners: List[Callable] = []
+        self._dc_listeners: List[Callable] = []
         self._processing_jobs: Dict[str, int] = {}
+        self._data_collections: Dict[str, int] = {}
 
     def subscribe(self, callback: Callable):
         self._listeners.append(callback)
+
+    def subscribe_dcg(self, callback: Callable):
+        self._dcg_listeners.append(callback)
+
+    def subscribe_dc(self, callback: Callable):
+        self._dc_listeners.append(callback)
 
     def new_processing_id(self, pid: int, tag: str):
         self._processing_jobs[tag] = pid
         for l in self._listeners:
             l(tag)
+
+    def register_dcg(self, dcg_id: int):
+        self.data_collection_group_id = dcg_id
+        for l in self._dcg_listeners:
+            l()
+
+    def register_dc(self, dcid: int, tag: str):
+        if tag not in list(self._data_collections):
+            self._data_collections[tag] = dcid
+            for l in self._dc_listeners:
+                l(tag)

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 from urllib.parse import ParseResult
 
 from murfey.client.watchdir import DirWatcher
@@ -39,6 +39,7 @@ class MurfeyInstanceEnvironment:
         self._dc_listeners: List[Callable] = []
         self._processing_jobs: Dict[str, int] = {}
         self._data_collections: Dict[str, int] = {}
+        self._data_collection_parameters: Dict[str, Any] = {}
 
     def subscribe(self, callback: Callable):
         self._listeners.append(callback)

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -465,6 +465,7 @@ class MurfeyTUI(App):
                 self.analyser._context._flush_data_collections
             )
             self._environment.subscribe_dc(self.analyser._context._flush_processing_job)
+            self._environment.subscribe(self.analyser._context._flush_preprocess)
             url = f"{str(self._url.geturl())}/visits/{str(self._visit)}/register_data_collection_group"
             dcg_data = {"experiment_type": "tomo"}
             requests.post(url, json=dcg_data)

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -11,6 +11,7 @@ from typing import Callable, Dict, List, NamedTuple, TypeVar, Union
 from urllib.parse import urlparse
 
 import requests
+from pydantic import BaseModel, ValidationError
 from rich.box import SQUARE
 from rich.logging import RichHandler
 from rich.panel import Panel
@@ -51,6 +52,7 @@ class InputResponse(NamedTuple):
     callback: Callable | None = None
     kwargs: dict | None = None
     form: dict | None = None
+    model: BaseModel | None = None
 
 
 class HoverVisit(Widget):
@@ -120,6 +122,16 @@ class QuickPrompt:
         return bool(self._text)
 
 
+def validate_form(form: dict, model: BaseModel) -> dict:
+    log.debug("validating", form)
+    try:
+        validated = model(**form)
+        return validated.dict()
+    except (AttributeError, ValidationError) as e:
+        log.debug(e)
+        return {}
+
+
 class InputBox(Widget):
     input_text: Union[Reactive[str], str] = Reactive("")
     prompt: str | QuickPrompt | None = ""
@@ -137,6 +149,7 @@ class InputBox(Widget):
         self._line = 0
         self._form_keys: List[str] = []
         self._unanswered_message = False
+        self._model: BaseModel | None = None
         super().__init__()
 
     @property
@@ -151,6 +164,7 @@ class InputBox(Widget):
             self.input_text = ""
             if msg.form:
                 self._form = msg.form
+                self._model = msg.model
             if msg.allowed_responses:
                 self.prompt = QuickPrompt(msg.question, msg.allowed_responses)
                 if msg.callback:
@@ -265,7 +279,12 @@ class InputBox(Widget):
             key.stop()
         elif key.key == Keys.Enter and self.current_callback:
             if self._form:
-                self.current_callback(self._form)
+                if validated_form := validate_form(self._form, self._model):
+                    self.current_callback(validated_form)
+                    self._form = {}
+                    self._form_keys = []
+                else:
+                    return
             else:
                 self.current_callback(self.input_text.replace(self._question, "", 1))
             self.current_callback = None
@@ -315,6 +334,17 @@ class LogBook(ScrollView):
                     self._logs.add_row(*nl[0])
             await self.update(self._logs, home=False)
             self.page_down()
+
+
+class DCParametersTomo(BaseModel):
+    voltage: float
+    pixel_size_on_image: str
+    experiment_type: str
+    image_size_x: int
+    image_size_y: int
+    tilt: int
+    acquisition_software: str
+    dose_per_frame: float
 
 
 class MurfeyTUI(App):
@@ -394,7 +424,11 @@ class MurfeyTUI(App):
                     InputResponse(
                         question="Data collection parameters:",
                         form=r.get("form", {}),
-                        callback=self.app._start_dc(r.get("form", {})),
+                        model=DCParametersTomo
+                        if self.analyser
+                        and isinstance(self.analyser._context, TomographyContext)
+                        else None,
+                        callback=self.app._start_dc,
                     )
                 )
                 self._dc_metadata = r.get("form", {})
@@ -425,6 +459,7 @@ class MurfeyTUI(App):
             self._request_destinations = True
 
     def _start_dc(self, json):
+        self._environment._data_collection_parameters = json
         if isinstance(self.analyser._context, TomographyContext):
             self._environment.subscribe_dcg(
                 self.analyser._context._flush_data_collections

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -426,6 +426,10 @@ class MurfeyTUI(App):
 
     def _start_dc(self, json):
         if isinstance(self.analyser._context, TomographyContext):
+            self._environment.subscribe_dcg(
+                self.analyser._context._flush_data_collections
+            )
+            self._environment.subscribe_dc(self.analyser._context._flush_processing_job)
             url = f"{str(self._url.geturl())}/visits/{str(self._visit)}/register_data_collection_group"
             dcg_data = {"experiment_type": "tomo"}
             requests.post(url, json=dcg_data)

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -368,7 +368,7 @@ class MurfeyTUI(App):
             urlparse("http://localhost:8000")
         )
         self._source = self._environment.source or Path(".")
-        self._url = self._environment.murfey_url
+        self._url = self._environment.url
         self._default_destination = self._environment.default_destination
         self._watcher = self._environment.watcher
         self.visits = visits or []
@@ -459,7 +459,7 @@ class MurfeyTUI(App):
             self._request_destinations = True
 
     def _start_dc(self, json):
-        self._environment._data_collection_parameters = json
+        self._environment.data_collection_parameters = json
         if isinstance(self.analyser._context, TomographyContext):
             self._environment.listeners["data_collection_group_id"] = {
                 self.analyser._context._flush_data_collections

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -461,11 +461,20 @@ class MurfeyTUI(App):
     def _start_dc(self, json):
         self._environment._data_collection_parameters = json
         if isinstance(self.analyser._context, TomographyContext):
-            self._environment.subscribe_dcg(
+            self._environment.listeners["data_collection_group_id"] = {
                 self.analyser._context._flush_data_collections
-            )
-            self._environment.subscribe_dc(self.analyser._context._flush_processing_job)
-            self._environment.subscribe(self.analyser._context._flush_preprocess)
+            }
+            self._environment.listeners["data_collection_ids"] = {
+                self.analyser._context._flush_processing_job
+            }
+            self._environment.listeners["autoproc_program_ids"] = {
+                self.analyser._context._flush_preprocess
+            }
+            # self._environment.subscribe_dcg(
+            #     self.analyser._context._flush_data_collections
+            # )
+            # self._environment.subscribe_dc(self.analyser._context._flush_processing_job)
+            # self._environment.subscribe(self.analyser._context._flush_preprocess)
             url = f"{str(self._url.geturl())}/visits/{str(self._visit)}/register_data_collection_group"
             dcg_data = {"experiment_type": "tomo"}
             requests.post(url, json=dcg_data)

--- a/src/murfey/client/websocket.py
+++ b/src/murfey/client/websocket.py
@@ -105,7 +105,10 @@ class WSApp:
             log.info(f"Interpreted data as {data!r}")
             if data.get("message") == "state-update":
                 if data["attribute"] == "data_collection_group_id" and self.environment:
-                    self.environment.data_collection_group_id = data["value"]
+                    self.environment.register_dcg(data["value"])
+                elif data["attribute"] == "data_collection_id" and self.environment:
+                    for k, v in data["value"].items():
+                        self.environment.register_dc(v, k)
         except Exception:
             pass
 

--- a/src/murfey/client/websocket.py
+++ b/src/murfey/client/websocket.py
@@ -102,21 +102,14 @@ class WSApp:
         log.info(f"Received message: {message!r}")
         try:
             data = json.loads(message)
-            # log.info(f"Interpreted data as {data!r}: {bool(self.environment)}: {data.get('message') == 'state-update'}: {data['attribute'] == 'autoproc_program_id'}")
             if data.get("message") == "state-update":
-                if data["attribute"] == "data_collection_group_id" and self.environment:
-                    self.environment.register_dcg(data["value"])
-                elif data["attribute"] == "data_collection_id" and self.environment:
-                    for k, v in data["value"].items():
-                        self.environment.register_dc(v, k)
-                elif data["attribute"] == "processing_job_id" and self.environment:
-                    for k, v in data["value"].items():
-                        self.environment.new_processing_id(v, k)
-                elif data["attribute"] == "autoproc_program_id" and self.environment:
-                    for k, v in data["value"].items():
-                        self.environment.register_app(v, k)
+                self._register_id(data["attribute"], data["value"])
         except Exception:
             pass
+
+    def _register_id(self, attribute: str, value):
+        if self.environment and hasattr(self.environment, attribute):
+            setattr(self.environment, attribute, value)
 
     def on_error(self, ws: websocket.WebSocketApp, error: websocket.WebSocketException):
         log.error(str(error))

--- a/src/murfey/client/websocket.py
+++ b/src/murfey/client/websocket.py
@@ -102,13 +102,19 @@ class WSApp:
         log.info(f"Received message: {message!r}")
         try:
             data = json.loads(message)
-            log.info(f"Interpreted data as {data!r}")
+            # log.info(f"Interpreted data as {data!r}: {bool(self.environment)}: {data.get('message') == 'state-update'}: {data['attribute'] == 'autoproc_program_id'}")
             if data.get("message") == "state-update":
                 if data["attribute"] == "data_collection_group_id" and self.environment:
                     self.environment.register_dcg(data["value"])
                 elif data["attribute"] == "data_collection_id" and self.environment:
                     for k, v in data["value"].items():
                         self.environment.register_dc(v, k)
+                elif data["attribute"] == "processing_job_id" and self.environment:
+                    for k, v in data["value"].items():
+                        self.environment.new_processing_id(v, k)
+                elif data["attribute"] == "autoproc_program_id" and self.environment:
+                    for k, v in data["value"].items():
+                        self.environment.register_app(v, k)
         except Exception:
             pass
 

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -286,48 +286,48 @@ def feedback_callback(header: dict, message: dict) -> None:
             _transport_object.transport.nack(header)
             return None
         logger.debug(f"registered: {message.get('tag')}")
-        if global_state.get("data_collection_id") and isinstance(
-            global_state["data_collection_id"], dict
+        if global_state.get("data_collection_ids") and isinstance(
+            global_state["data_collection_ids"], dict
         ):
-            global_state["data_collection_id"] = {
-                **global_state["data_collection_id"],
+            global_state["data_collection_ids"] = {
+                **global_state["data_collection_ids"],
                 message.get("tag"): dcid,
             }
         else:
-            global_state["data_collection_id"] = {message.get("tag"): dcid}
+            global_state["data_collection_ids"] = {message.get("tag"): dcid}
         if _transport_object:
             _transport_object.transport.ack(header)
         return None
     elif message["register"] == "processing_job":
         logger.debug(f"Registering processing job: {message.get('tag')}")
-        assert isinstance(global_state["data_collection_id"], dict)
-        _dcid = global_state["data_collection_id"][message["tag"]]
+        assert isinstance(global_state["data_collection_ids"], dict)
+        _dcid = global_state["data_collection_ids"][message["tag"]]
         record = ProcessingJob(dataCollectionId=_dcid, recipe=message["recipe"])
         pid = _register(record, header)
         if pid is None and _transport_object:
             _transport_object.transport.nack(header)
             return None
-        if global_state.get("processing_job_id"):
-            assert isinstance(global_state["processing_job_id"], dict)
-            global_state["processing_job_id"] = {
-                **global_state["processing_job_id"],
+        if global_state.get("processing_job_ids"):
+            assert isinstance(global_state["processing_job_ids"], dict)
+            global_state["processing_job_ids"] = {
+                **global_state["processing_job_ids"],
                 message.get("tag"): pid,
             }
         else:
-            global_state["processing_job_id"] = {message["tag"]: pid}
+            global_state["processing_job_ids"] = {message["tag"]: pid}
         record = AutoProcProgram(processingJobId=pid)
         appid = _register(record, header)
         if appid is None and _transport_object:
             _transport_object.transport.nack(header)
             return None
-        if global_state.get("autoproc_program_id"):
-            assert isinstance(global_state["autoproc_program_id"], dict)
-            global_state["autoproc_program_id"] = {
-                **global_state["autoproc_program_id"],
+        if global_state.get("autoproc_program_ids"):
+            assert isinstance(global_state["autoproc_program_ids"], dict)
+            global_state["autoproc_program_ids"] = {
+                **global_state["autoproc_program_ids"],
                 message.get("tag"): appid,
             }
         else:
-            global_state["autoproc_program_id"] = {message["tag"]: appid}
+            global_state["autoproc_program_ids"] = {message["tag"]: appid}
         if _transport_object:
             _transport_object.transport.ack(header)
         return None

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -299,8 +299,8 @@ class DCParameters(BaseModel):
     voltage: float
     pixel_size_on_image: str
     experiment_type: str
-    image_size_x: float
-    image_size_y: float
+    image_size_x: int
+    image_size_y: int
     tilt: int
     file_extension: str
     acquisition_software: str

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -209,6 +209,7 @@ class ProcessFile(BaseModel):
     data_collection_id: int
     image_number: int
     mc_uuid: int
+    movie_uuid: int
     autoproc_program_id: int
     pixel_size: float
 
@@ -224,14 +225,14 @@ async def request_tomography_preprocessing(proc_file: ProcessFile):
         },
     }
     log.info(f"Sending Zocalo message {zocalo_message}")
-    if _transport_object:
-        _transport_object.transport.send("processing_recipe", zocalo_message)
-    else:
-        log.error(
-            f"Processing was requested for {proc_file.name} but no Zocalo transport object was found"
-        )
-        return proc_file
-    await ws.manager.broadcast(f"Processing requested for {proc_file.name}")
+    # if _transport_object:
+    #     _transport_object.transport.send("processing_recipe", zocalo_message)
+    # else:
+    #     log.error(
+    #         f"Processing was requested for {proc_file.name} but no Zocalo transport object was found"
+    #     )
+    #     return proc_file
+    # await ws.manager.broadcast(f"Processing requested for {proc_file.name}")
     return proc_file
 
 

--- a/src/murfey/server/main.py
+++ b/src/murfey/server/main.py
@@ -308,6 +308,11 @@ class DCParameters(BaseModel):
     tag: str
 
 
+class ProcessingJobParameters(BaseModel):
+    tag: str
+    recipe: str
+
+
 @app.post("/visits/{visit_name}/register_data_collection_group")
 def register_dc_group(visit_name, dcg_params: DCGroupParameters):
     ispyb_proposal_code = visit_name[:2]
@@ -358,10 +363,29 @@ def start_dc(visit_name, dc_params: DCParameters):
         "image_size_x": dc_params.image_size_x,
         "image_size_y": dc_params.image_size_y,
         "acquisition_software": dc_params.acquisition_software,
+        "tag": dc_params.tag,
     }
 
     if _transport_object:
+        log.debug(f"Send registration message to murfey_feedback: {dc_parameters}")
         _transport_object.transport.send(
             "murfey_feedback", {"register": "data_collection", **dc_parameters}
         )
     return dc_params
+
+
+@app.post("/visits/{visit_name}/register_processing_job")
+def register_proc(visit_name, proc_params: ProcessingJobParameters):
+    proc_parameters = {
+        "recipe": proc_params.recipe,
+        "tag": proc_params.tag,
+    }
+
+    if _transport_object:
+        log.debug(
+            f"Send processing registration message to murfey_feedback: {proc_parameters}"
+        )
+        _transport_object.transport.send(
+            "murfey_feedback", {"register": "processing_job", **proc_parameters}
+        )
+    return proc_params

--- a/tests/client/test_context.py
+++ b/tests/client/test_context.py
@@ -57,3 +57,42 @@ def test_tomography_context_add_tomo_tilt_delayed_tilt(tmp_path):
     )
     assert context._completed_tilt_series == ["1"]
     assert new_series == ["1"]
+
+
+def test_tomography_context_initialisation_for_serialem():
+    context = TomographyContext("serialem")
+    assert not context._last_transferred_file
+    assert context._acquisition_software == "serialem"
+
+
+def test_tomography_context_add_serialem_tilt(tmp_path):
+    context = TomographyContext("serialem")
+    context.post_transfer(tmp_path / "tomography_1_2_30.tiff", role="detector")
+    assert context._tilt_series == {"1": [tmp_path / "tomography_1_2_30.tiff"]}
+    assert context._last_transferred_file == tmp_path / "tomography_1_2_30.tiff"
+    context.post_transfer(tmp_path / "tomography_1_2_-30.tiff", role="detector")
+    assert context._tilt_series == {
+        "1": [tmp_path / "tomography_1_2_30.tiff", tmp_path / "tomography_1_2_-30.tiff"]
+    }
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "tomography_2_2_30.tiff", role="detector")
+    assert len(context._tilt_series.values()) == 2
+    assert context._completed_tilt_series == ["1"]
+
+
+def test_tomography_context_add_serialem_decimal_tilt(tmp_path):
+    context = TomographyContext("serialem")
+    context.post_transfer(tmp_path / "tomography_1_2_30.0.tiff", role="detector")
+    assert context._tilt_series == {"1": [tmp_path / "tomography_1_2_30.0.tiff"]}
+    assert context._last_transferred_file == tmp_path / "tomography_1_2_30.0.tiff"
+    context.post_transfer(tmp_path / "tomography_1_2_-30.0.tiff", role="detector")
+    assert context._tilt_series == {
+        "1": [
+            tmp_path / "tomography_1_2_30.0.tiff",
+            tmp_path / "tomography_1_2_-30.0.tiff",
+        ]
+    }
+    assert not context._completed_tilt_series
+    context.post_transfer(tmp_path / "tomography_2_2_30.0.tiff", role="detector")
+    assert len(context._tilt_series.values()) == 2
+    assert context._completed_tilt_series == ["1"]

--- a/tests/client/test_instance_environment.py
+++ b/tests/client/test_instance_environment.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+
+from murfey.client.instance_environment import MurfeyInstanceEnvironment
+
+
+@pytest.fixture
+def env():
+    return MurfeyInstanceEnvironment(
+        urlparse("http://localhost:8000", allow_fragments=False)
+    )
+
+
+def test_murfey_instance_environment_subscribe(env):
+    class DummyContext:
+        elem = None
+
+        def set_elem(self, new_elem: str):
+            self.elem = new_elem
+
+    dc = DummyContext()
+    env.subscribe(dc.set_elem)
+    assert len(env._listeners) == 1
+    env.register_app(1, "a")
+    assert dc.elem == "a"

--- a/tests/client/test_instance_environment.py
+++ b/tests/client/test_instance_environment.py
@@ -10,11 +10,13 @@ from murfey.client.instance_environment import MurfeyInstanceEnvironment
 @pytest.fixture
 def env():
     return MurfeyInstanceEnvironment(
-        urlparse("http://localhost:8000", allow_fragments=False)
+        url=urlparse("http://localhost:8000", allow_fragments=False)
     )
 
 
 def test_murfey_instance_environment_subscribe(env):
+    assert env.url == urlparse("http://localhost:8000", allow_fragments=False)
+
     class DummyContext:
         elem = None
 
@@ -22,7 +24,9 @@ def test_murfey_instance_environment_subscribe(env):
             self.elem = new_elem
 
     dc = DummyContext()
-    env.subscribe(dc.set_elem)
-    assert len(env._listeners) == 1
-    env.register_app(1, "a")
+    env.listeners["autoproc_program_ids"] = {dc.set_elem}
+    assert len(env.listeners["autoproc_program_ids"]) == 1
+    env.autoproc_program_ids = {"a": 1}
     assert dc.elem == "a"
+    env.autoproc_program_ids = {"a": 1, "b": 2}
+    assert dc.elem == "b"


### PR DESCRIPTION
At various stages primary key IDs obtained on insert into ISPyB are needed to trigger processing. This should mostly handle this need by triggering callback functions that clear buffered API calls once the relevant ID becomes available. Will benefit from some cleanup in the future