### PR TITLE
Add ability to only rsync recent or active directories

### DIFF
--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -120,6 +120,12 @@ def run():
         default=-1,
         help="Only consider top level directories that have appeared more recently than this many hours ago",
     )
+    parser.add_argument(
+        "--real_dc",
+        action="store_true",
+        default=False,
+        help="Actually perform data collection related calls to API (will do inserts in ISPyB)",
+    )
 
     args = parser.parse_args()
 
@@ -213,6 +219,7 @@ def run():
         visits=ongoing_visits,
         queues={"input": input_queue, "logs": log_queue},
         status_bar=status_bar,
+        dummy_dc=not args.real_dc,
     )
     rich_handler.redirect = False
 

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -361,6 +361,7 @@ class MurfeyTUI(App):
         visits: List[str] | None = None,
         queues: Dict[str, Queue] | None = None,
         status_bar: StatusBar | None = None,
+        dummy_dc: bool = True,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -379,6 +380,7 @@ class MurfeyTUI(App):
         self._tmp_responses: List[dict] = []
         self._visit = ""
         self._dc_metadata: dict = {}
+        self._dummy_dc = dummy_dc
 
     @property
     def role(self) -> str:
@@ -409,7 +411,9 @@ class MurfeyTUI(App):
         if self.rsync_process:
             self.rsync_process.subscribe(rsync_result)
             self.rsync_process.start()
-            self.analyser = Analyser(environment=self._environment)
+            self.analyser = Analyser(
+                environment=self._environment if not self._dummy_dc else None
+            )
             if self._watcher:
                 self._watcher.subscribe(self.rsync_process.enqueue)
                 self._watcher.subscribe(self.analyser.enqueue)
@@ -455,6 +459,8 @@ class MurfeyTUI(App):
             self._tmp_responses.append(response)
 
     def _start_dc(self, json):
+        if self._dummy_dc:
+            return
         self._environment.data_collection_parameters = json
         if isinstance(self.analyser._context, TomographyContext):
             self._environment.listeners["data_collection_group_id"] = {

--- a/src/murfey/client/watchdir.py
+++ b/src/murfey/client/watchdir.py
@@ -31,6 +31,8 @@ class DirWatcher(murfey.util.Observer):
         self._file_candidates: dict[str, _FileInfo] = {}
         self._statusbar = status_bar
         self.settling_time = settling_time
+        self._modification_overwrite: float | None = None
+        self._init_time: float = time.time()
 
     def __repr__(self) -> str:
         return f"<DirWatcher ({self._basepath})>"
@@ -38,7 +40,9 @@ class DirWatcher(murfey.util.Observer):
     def scan(self, modification_time: float | None = None):
         try:
             t_start = time.perf_counter()
-            filelist = self._scan_directory(modification_time=modification_time)
+            filelist = self._scan_directory(
+                modification_time=self._modification_overwrite or modification_time
+            )
             t_scan = time.perf_counter() - t_start
             log.info(f"Scan of {self._basepath} completed in {t_scan:.1f} seconds")
             scan_completion = time.time()
@@ -70,29 +74,57 @@ class DirWatcher(murfey.util.Observer):
                             and file_stat.st_ctime
                             <= self._file_candidates[x].modification_time
                         ):
-                            log.debug(
-                                f"File {Path(x).name!r} is ready to be transferred"
-                            )
-                            if self._statusbar:
-                                log.info("Increasing number to be transferred")
-                                with self._statusbar.lock:
-                                    self._statusbar.transferred = [
-                                        self._statusbar.transferred[0],
-                                        self._statusbar.transferred[1] + 1,
-                                    ]
-                            self.notify(Path(x))
-                            del self._file_candidates[x]
+                            if (
+                                not modification_time
+                                and not self._modification_overwrite
+                            ):
+                                if file_stat.st_mtime >= self._init_time:
+                                    top_level_dir = (
+                                        Path(self._basepath)
+                                        / Path(x).relative_to(self._basepath).parts[0]
+                                    )
+                                    if top_level_dir.is_dir():
+                                        # touch the changing directory so that when _modification_overwrite is set
+                                        # we don't potentially catch old directories that aren't changing
+                                        # this means it will only autodetect new directories from this point
+                                        top_level_dir.touch(exist_ok=True)
+                                        filelist.update(
+                                            self._scan_directory(
+                                                path=str(top_level_dir)
+                                            )
+                                        )
+                                        self._modification_overwrite = max(
+                                            top_level_dir.stat().st_mtime,
+                                            top_level_dir.stat().st_ctime,
+                                        )
+                            else:
+                                self._notify_for_transfer(x)
                             continue
                     except Exception as e:
                         log.error(f"Exception encountered: {e}", exc_info=True)
                         return
 
                 if self._lastscan is not None and x not in self._lastscan:
-                    log.debug(f"Found file {Path(x).name!r} for future transfer")
+                    log.debug(
+                        f"Found file {Path(x).name!r} for potential future transfer"
+                    )
 
             self._lastscan = filelist
         except Exception as e:
             log.error(f"Exception encountered: {e}")
+
+    def _notify_for_transfer(self, file_candidate: str):
+        log.debug(f"File {Path(file_candidate).name!r} is ready to be transferred")
+        if self._statusbar:
+            log.info("Increasing number to be transferred")
+            with self._statusbar.lock:
+                self._statusbar.transferred = [
+                    self._statusbar.transferred[0],
+                    self._statusbar.transferred[1] + 1,
+                ]
+
+        self.notify(Path(file_candidate))
+        del self._file_candidates[file_candidate]
 
     def _scan_directory(
         self, path: str = "", modification_time: float | None = None
@@ -111,7 +143,7 @@ class DirWatcher(murfey.util.Observer):
         for entry in directory_contents:
             entry_name = os.path.join(path, entry.name)
             if entry.is_dir() and (
-                modification_time is None or entry.stat().st_ctime < modification_time
+                modification_time is None or entry.stat().st_ctime >= modification_time
             ):
                 result.update(self._scan_directory(entry_name))
             else:
@@ -123,17 +155,15 @@ class DirWatcher(murfey.util.Observer):
                     # In this case we can just ignore the file.
                     continue
                 if modification_time:
-                    if max(file_stat.st_mtime, file_stat.st_ctime) > modification_time:
-                        result[
-                            str(Path(self._basepath) / path / entry_name)
-                        ] = _FileInfo(
+                    if max(file_stat.st_mtime, file_stat.st_ctime) >= modification_time:
+                        result[str(Path(self._basepath) / entry_name)] = _FileInfo(
                             size=file_stat.st_size,
                             modification_time=max(
                                 file_stat.st_mtime, file_stat.st_ctime
                             ),
                         )
                 else:
-                    result[str(Path(self._basepath) / path / entry_name)] = _FileInfo(
+                    result[str(Path(self._basepath) / entry_name)] = _FileInfo(
                         size=file_stat.st_size,
                         modification_time=max(file_stat.st_mtime, file_stat.st_ctime),
                     )


### PR DESCRIPTION
- `--appearance_time` flag for client provides an amount of the past from which directories will be copied in hours
- if `--appearance_time` is not provided then `DirWatcher` will find the first top level directory (with respect to the base path) in which a new file appears and `rsync` that directory and any other more recently created directories
- `--real_dc` flag for client turns on data collection related API calls (i.e. ISPyB inserts and Zocalo processing triggers)
- default real data collections to false at the moment for debugging