### PR TITLE
Fix suggested destination path or remote rsync

### DIFF
--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -172,18 +172,12 @@ class HoverVisit(Widget):
                 else:
                     _default = "unknown"
                 if self.app._environment.processing_only_mode:
-                    self.app._start_rsyncer(
-                        str(Path(_default).relative_to(machine_data["rsync_basepath"]))
-                    )
+                    self.app._start_rsyncer(_default)
                 else:
                     self.app._queues["input"].put_nowait(
                         InputResponse(
                             question="Transfer to: ",
-                            default=str(
-                                Path(_default).relative_to(
-                                    machine_data["rsync_basepath"]
-                                )
-                            ),
+                            default=_default,
                             callback=self.app._start_rsyncer,
                         )
                     )

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -172,12 +172,18 @@ class HoverVisit(Widget):
                 else:
                     _default = "unknown"
                 if self.app._environment.processing_only_mode:
-                    self.app._start_rsyncer(_default)
+                    self.app._start_rsyncer(
+                        str(Path(_default).relative_to(machine_data["rsync_basepath"]))
+                    )
                 else:
                     self.app._queues["input"].put_nowait(
                         InputResponse(
                             question="Transfer to: ",
-                            default=_default,
+                            default=str(
+                                Path(_default).relative_to(
+                                    machine_data["rsync_basepath"]
+                                )
+                            ),
                             callback=self.app._start_rsyncer,
                         )
                     )

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -320,7 +320,7 @@ def suggest_path(visit_name, params: SuggestedPathParameters):
     while check_path.exists():
         count = count + 1 if count else 2
         check_path = check_path.parent / f"{check_path_name}{count}"
-    return {"suggested_path": check_path}
+    return {"suggested_path": check_path.relative_to(machine_config.rsync_basepath)}
 
 
 @router.post("/visits/{visit_name}/register_data_collection_group")


### PR DESCRIPTION
The destination path for a remote rsync operation must be relative to the rsync base path of the rsync daemon