### PR TITLE
Reduce the number of metadata reads from mdoc files

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -160,7 +160,7 @@ class Analyser(Observer):
                             dc_metadata = self._context.gather_metadata(
                                 transferred_file.with_suffix(".xml")
                             )
-                        if not dc_metadata:
+                        if not dc_metadata and not self._force_mdoc_metadata:
                             self._unseen_xml.append(transferred_file)
                         else:
                             self._unseen_xml = []


### PR DESCRIPTION
Missed a case where unseen xmls are registered even when forcing mdoc reading