### PR TITLE
Parse file names based on acquisition software version

### DIFF
--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -270,6 +270,7 @@ def run():
 
     instance_environment = MurfeyInstanceEnvironment(
         url=murfey_url,
+        software_versions=machine_data.software_versions,
         source=Path(args.source),
         watcher=source_watcher,
         default_destination=args.destination

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -474,9 +474,9 @@ class TomographyContext(Context):
                         f"Extraction routines for TFS Tomo version {tomo_version} unknown"
                     )
             else:
-                tilt_info_extraction = tomo_tilt_info["5.11"]
+                tilt_info_extraction = tomo_tilt_info["5.7"]
         else:
-            tilt_info_extraction = tomo_tilt_info["5.11"]
+            tilt_info_extraction = tomo_tilt_info["5.7"]
         return self._add_tilt(
             file_path,
             tilt_info_extraction.series,

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -474,9 +474,9 @@ class TomographyContext(Context):
                         f"Extraction routines for TFS Tomo version {tomo_version} unknown"
                     )
             else:
-                tilt_info_extraction = tomo_tilt_info["v5.10"]
+                tilt_info_extraction = tomo_tilt_info["v5.11"]
         else:
-            tilt_info_extraction = tomo_tilt_info["v5.10"]
+            tilt_info_extraction = tomo_tilt_info["v5.11"]
         return self._add_tilt(
             file_path,
             tilt_info_extraction.series,

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -474,9 +474,9 @@ class TomographyContext(Context):
                         f"Extraction routines for TFS Tomo version {tomo_version} unknown"
                     )
             else:
-                tilt_info_extraction = tomo_tilt_info["v5.11"]
+                tilt_info_extraction = tomo_tilt_info["5.11"]
         else:
-            tilt_info_extraction = tomo_tilt_info["v5.11"]
+            tilt_info_extraction = tomo_tilt_info["5.11"]
         return self._add_tilt(
             file_path,
             tilt_info_extraction.series,

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -9,6 +9,7 @@ import requests
 import xmltodict
 from pydantic import BaseModel
 
+from murfey.client.contexts.tomo import tomo_tilt_info
 from murfey.client.instance_environment import (
     MovieID,
     MovieTracker,
@@ -465,46 +466,22 @@ class TomographyContext(Context):
     def _add_tomo_tilt(
         self, file_path: Path, environment: MurfeyInstanceEnvironment | None = None
     ) -> List[str]:
-        if "[" in file_path.name:
-            return self._add_tilt(
-                file_path,
-                lambda x: x.name.split("_")[1],
-                lambda x: x.name.split("[")[1].split("]")[0],
-                lambda x: x.name.split("_")[0],
-                environment=environment,
-            )
-
-        def _get_slice_index(tag: str) -> int:
-            slice_index = 0
-            for i, ch in enumerate(tag[::-1]):
-                if not ch.isnumeric():
-                    slice_index = -i
-                    break
-            if not slice_index:
-                raise ValueError(
-                    f"The file tag {tag} does not end in numeric characters or is entirely numeric: cannot parse"
-                )
-            return slice_index
-
-        def _extract_tilt_series(p: Path) -> str:
-            tag = p.name.split("_")[0]
-            slice_index = _get_slice_index(tag)
-            return tag[slice_index:]
-
-        def _extract_tilt_tag(p: Path) -> str:
-            tag = p.name.split("_")[0]
-            slice_index = _get_slice_index(tag)
-            return tag[:slice_index]
-
-        def _extract_tilt_angle(p: Path) -> str:
-            _split = p.name.split("_")[2].split(".")
-            return ".".join(_split[:-1])
-
+        if environment:
+            if tomo_version := environment.software_verisons.get("tomo"):
+                tilt_info_extraction = tomo_tilt_info.get(tomo_version)
+                if not tilt_info_extraction:
+                    raise ValueError(
+                        f"Extraction routines for TFS Tomo version {tomo_version} unknown"
+                    )
+            else:
+                tilt_info_extraction = tomo_tilt_info["v5.10"]
+        else:
+            tilt_info_extraction = tomo_tilt_info["v5.10"]
         return self._add_tilt(
             file_path,
-            _extract_tilt_series,
-            _extract_tilt_angle,
-            _extract_tilt_tag,
+            tilt_info_extraction.series,
+            tilt_info_extraction.angle,
+            tilt_info_extraction.tag,
             environment=environment,
         )
 

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -22,7 +22,7 @@ def _get_tilt_tag_v5_8(p: Path) -> str:
     return p.name.split("_")[0]
 
 
-def _get_slice_index_v5_10(tag: str) -> int:
+def _get_slice_index_v5_11(tag: str) -> int:
     slice_index = 0
     for i, ch in enumerate(tag[::-1]):
         if not ch.isnumeric():
@@ -35,19 +35,19 @@ def _get_slice_index_v5_10(tag: str) -> int:
     return slice_index
 
 
-def _get_tilt_series_v5_10(p: Path) -> str:
+def _get_tilt_series_v5_11(p: Path) -> str:
     tag = p.name.split("_")[0]
-    slice_index = _get_slice_index_v5_10(tag)
+    slice_index = _get_slice_index_v5_11(tag)
     return tag[slice_index:]
 
 
-def _get_tilt_angle_v5_10(p: Path) -> str:
+def _get_tilt_angle_v5_11(p: Path) -> str:
     tag = p.name.split("_")[0]
-    slice_index = _get_slice_index_v5_10(tag)
+    slice_index = _get_slice_index_v5_11(tag)
     return tag[:slice_index]
 
 
-def _get_tilt_tag_v5_10(p: Path) -> str:
+def _get_tilt_tag_v5_11(p: Path) -> str:
     _split = p.name.split("_")[2].split(".")
     return ".".join(_split[:-1])
 
@@ -56,7 +56,7 @@ tomo_tilt_info = {
     "5.8": TiltInfoExtraction(
         _get_tilt_series_v5_8, _get_tilt_angle_v5_8, _get_tilt_tag_v5_8
     ),
-    "5.10": TiltInfoExtraction(
-        _get_tilt_series_v5_10, _get_tilt_angle_v5_10, _get_tilt_tag_v5_10
+    "5.11": TiltInfoExtraction(
+        _get_tilt_series_v5_11, _get_tilt_angle_v5_11, _get_tilt_tag_v5_11
     ),
 }

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -22,8 +22,41 @@ def _get_tilt_tag_v5_8(p: Path) -> str:
     return p.name.split("_")[0]
 
 
+def _get_slice_index_v5_10(tag: str) -> int:
+    slice_index = 0
+    for i, ch in enumerate(tag[::-1]):
+        if not ch.isnumeric():
+            slice_index = -i
+            break
+    if not slice_index:
+        raise ValueError(
+            f"The file tag {tag} does not end in numeric characters or is entirely numeric: cannot parse"
+        )
+    return slice_index
+
+
+def _get_tilt_series_v5_10(p: Path) -> str:
+    tag = p.name.split("_")[0]
+    slice_index = _get_slice_index_v5_10(tag)
+    return tag[slice_index:]
+
+
+def _get_tilt_angle_v5_10(p: Path) -> str:
+    tag = p.name.split("_")[0]
+    slice_index = _get_slice_index_v5_10(tag)
+    return tag[:slice_index]
+
+
+def _get_tilt_tag_v5_10(p: Path) -> str:
+    _split = p.name.split("_")[2].split(".")
+    return ".".join(_split[:-1])
+
+
 tomo_tilt_info = {
     "5.8": TiltInfoExtraction(
         _get_tilt_series_v5_8, _get_tilt_angle_v5_8, _get_tilt_tag_v5_8
-    )
+    ),
+    "5.10": TiltInfoExtraction(
+        _get_tilt_series_v5_10, _get_tilt_angle_v5_10, _get_tilt_tag_v5_10
+    ),
 }

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+
+class TiltInfoExtraction(NamedTuple):
+    series: Callable[[Path], str]
+    angle: Callable[[Path], str]
+    tag: Callable[[Path], str]
+
+
+def _get_tilt_series_v5_8(p: Path) -> str:
+    return p.name.split("_")[1]
+
+
+def _get_tilt_angle_v5_8(p: Path) -> str:
+    return p.name.split("[")[1].split("]")[0]
+
+
+def _get_tilt_tag_v5_8(p: Path) -> str:
+    return p.name.split("_")[0]
+
+
+tomo_tilt_info = {
+    "5.8": TiltInfoExtraction(
+        _get_tilt_series_v5_8, _get_tilt_angle_v5_8, _get_tilt_tag_v5_8
+    )
+}

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -10,15 +10,15 @@ class TiltInfoExtraction(NamedTuple):
     tag: Callable[[Path], str]
 
 
-def _get_tilt_series_v5_8(p: Path) -> str:
+def _get_tilt_series_v5_7(p: Path) -> str:
     return p.name.split("_")[1]
 
 
-def _get_tilt_angle_v5_8(p: Path) -> str:
+def _get_tilt_angle_v5_7(p: Path) -> str:
     return p.name.split("[")[1].split("]")[0]
 
 
-def _get_tilt_tag_v5_8(p: Path) -> str:
+def _get_tilt_tag_v5_7(p: Path) -> str:
     return p.name.split("_")[0]
 
 
@@ -82,8 +82,8 @@ def _get_tilt_tag_v5_12(p: Path) -> str:
 
 
 tomo_tilt_info = {
-    "5.8": TiltInfoExtraction(
-        _get_tilt_series_v5_8, _get_tilt_angle_v5_8, _get_tilt_tag_v5_8
+    "5.7": TiltInfoExtraction(
+        _get_tilt_series_v5_7, _get_tilt_angle_v5_7, _get_tilt_tag_v5_7
     ),
     "5.11": TiltInfoExtraction(
         _get_tilt_series_v5_11, _get_tilt_angle_v5_11, _get_tilt_tag_v5_11

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable, NamedTuple
+from typing import Callable, List, NamedTuple
 
 
 class TiltInfoExtraction(NamedTuple):
@@ -52,11 +52,45 @@ def _get_tilt_tag_v5_11(p: Path) -> str:
     return ".".join(_split[:-1])
 
 
+def _find_angle_index(split_name: List[str]) -> int:
+    for i, part in enumerate(split_name):
+        if "." in part:
+            return i
+    return 0
+
+
+def _get_tilt_series_v5_12(p: Path) -> str:
+    split_name = p.name.split("_")
+    angle_idx = _find_angle_index(split_name)
+    if split_name[angle_idx - 2].isnumeric():
+        return split_name[angle_idx - 2]
+    return "0"
+
+
+def _get_tilt_angle_v5_12(p: Path) -> str:
+    split_name = p.name.split("_")
+    angle_idx = _find_angle_index(split_name)
+    return split_name[angle_idx]
+
+
+def _get_tilt_tag_v5_12(p: Path) -> str:
+    split_name = p.name.split("_")
+    angle_idx = _find_angle_index(split_name)
+    if split_name[angle_idx - 2].isnumeric():
+        return "_".join(split_name[: angle_idx - 2])
+    return "_".join(split_name[: angle_idx - 1])
+
+
 tomo_tilt_info = {
     "5.8": TiltInfoExtraction(
         _get_tilt_series_v5_8, _get_tilt_angle_v5_8, _get_tilt_tag_v5_8
     ),
     "5.11": TiltInfoExtraction(
         _get_tilt_series_v5_11, _get_tilt_angle_v5_11, _get_tilt_tag_v5_11
+    ),
+    "5.12": TiltInfoExtraction(
+        _get_tilt_series_v5_12,
+        _get_tilt_angle_v5_12,
+        _get_tilt_tag_v5_12,
     ),
 }

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -27,6 +27,7 @@ global_env_lock = RLock()
 
 class MurfeyInstanceEnvironment(BaseModel):
     url: ParseResult
+    software_verisons: Dict[str, str] = {}
     source: Optional[Path] = None
     default_destination: str = ""
     watcher: Optional[DirWatcher] = None

--- a/src/murfey/server/config.py
+++ b/src/murfey/server/config.py
@@ -12,6 +12,7 @@ class MachineConfig(BaseModel):
     calibrations: Dict[str, Union[dict, float]]
     data_directories: Dict[Path, str]
     rsync_basepath: Path
+    software_versions: Dict[str, str] = {}
     rsync_module: str = ""
     gain_reference_directory: Optional[Path] = None
     processed_directory_name: str = "processed"


### PR DESCRIPTION
Software versions can be specified in the machine configuration. This is only setup got parsing of files from TFS Tomography at the moment. Should resolve #103 