### PR TITLE
Add a default gain reference path

### DIFF
--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -255,7 +255,12 @@ class InputBox(Widget):
                 self._unanswered_message = True
             self.input_text = ""
             if msg.form:
-                self._form = msg.form
+                self._form = {
+                    k: v
+                    if k != "gain_ref" and v
+                    else f"data/2022/{self.app._environment.visit}/processing/gain.mrc"
+                    for k, v in msg.form.items()
+                }
                 self._model = msg.model
             if msg.allowed_responses:
                 self.prompt = QuickPrompt(msg.question, msg.allowed_responses)

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -245,7 +245,9 @@ async def request_tomography_preprocessing(visit_name: str, proc_file: ProcessFi
             "mc_uuid": proc_file.mc_uuid,
             "ft_bin": proc_file.mc_binning,
             "fm_dose": proc_file.dose_per_frame,
-            "gain_ref": proc_file.gain_ref,
+            "gain_ref": str(machine_config.rsync_basepath / proc_file.gain_ref)
+            if proc_file.gain_ref
+            else proc_file.gain_ref,
         },
     }
     # log.info(f"Sending Zocalo message {zocalo_message}")


### PR DESCRIPTION
This will make the user experience easier by providing at least most of the gain reference path. This is DLS specific at the moment: `processing/gain.mrc` within the visit directory.