### PR TITLE
Read metadata from any mdoc file by default

### DIFF
--- a/src/murfey/client/__init__.py
+++ b/src/murfey/client/__init__.py
@@ -165,10 +165,10 @@ def run():
         help="Perform rsync transfers locally rather than remotely",
     )
     parser.add_argument(
-        "--force_mdoc_metadata",
+        "--ignore_mdoc_metadata",
         action="store_true",
         default=False,
-        help="Force metadata to be read from mdoc files",
+        help="Do not attempt to read metadata from all mdoc files",
     )
 
     args = parser.parse_args()
@@ -293,7 +293,7 @@ def run():
     analyser = Analyser(
         instance_environment.source,
         environment=instance_environment if not args.fake_dc else None,
-        force_mdoc_metadata=args.force_mdoc_metadata,
+        force_mdoc_metadata=not args.ignore_mdoc_metadata,
     )
     # source_watcher.subscribe(analyser.enqueue)
     rsync_process.subscribe(analyser.enqueue)


### PR DESCRIPTION
Changes the behaviour of a command line argument so that this is `True` by default for convenience