### PR TITLE
Add an option to remove files after rsync when closing client

### DIFF
--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -766,9 +766,16 @@ class MurfeyTUI(App):
         await self.shutdown()
 
     async def action_clear(self) -> None:
+        destination = ""
+        if self.rsync_process:
+            destination = (
+                self.rsync_process._remote.split("::")[1]
+                if "::" in self.rsync_process._remote
+                else self.rsync_process._remote
+            )
         self._queues["input"].put_nowait(
             InputResponse(
-                question="Are you sure you want to remove all copied data?",
+                question=f"Are you sure you want to remove all copied data? [{self._source} -> {destination}]",
                 allowed_responses=["y", "n"],
                 callback=partial(self._confirm_clear),
             )

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -776,5 +776,24 @@ class MurfeyTUI(App):
 
     def _confirm_clear(self, response: str):
         if response == "y":
+            if self._do_transfer and self.rsync_process:
+                destination = (
+                    self.rsync_process._remote.split("::")[1]
+                    if "::" in self.rsync_process._remote
+                    else self.rsync_process._remote
+                )
+                self.rsync_process.stop()
+                if self.analyser:
+                    self.analyser.stop()
+                self.rsync_process = RSyncer(
+                    self._source,
+                    basepath_remote=Path(destination),
+                    server_url=self._url,
+                    local=self._environment.demo,
+                    status_bar=self._statusbar,
+                    do_transfer=self._do_transfer,
+                    remove_files=True,
+                )
+
             loop = asyncio.get_running_loop()
             loop.create_task(self.action_quit())

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-# import asyncio
+import asyncio
+
 # import contextlib
 import copy
 import logging
@@ -716,6 +717,7 @@ class MurfeyTUI(App):
 
     async def on_load(self, event):
         await self.bind("q", "quit", show=True)
+        await self.bind("c", "clear", show=True)
 
     async def on_mount(self) -> None:
         self.input_box = InputBox(self, queue=self._queues.get("input"))
@@ -762,3 +764,17 @@ class MurfeyTUI(App):
         if self.analyser:
             self.analyser.stop()
         await self.shutdown()
+
+    async def action_clear(self) -> None:
+        self._queues["input"].put_nowait(
+            InputResponse(
+                question="Are you sure you want to remove all copied data?",
+                allowed_responses=["y", "n"],
+                callback=partial(self._confirm_clear),
+            )
+        )
+
+    def _confirm_clear(self, response: str):
+        if response == "y":
+            loop = asyncio.get_running_loop()
+            loop.create_task(self.action_quit())


### PR DESCRIPTION
Press "c" to be prompted about whether to remove files that have been copied. If yes this will run a final `rsync` on the files in source to the previously used destination to make sure that all copies are complete.