### PR TITLE
Use mdocs to determine tilt series completion

### DIFF
--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -425,8 +425,7 @@ class TomographyContext(Context):
                     newly_completed_series.append(tilt_series)
                 for ts, ta in self._tilt_series.items():
                     if (
-                        len(ta) >= tilt_series_size
-                        and ts not in self._completed_tilt_series
+                        ts not in self._completed_tilt_series
                         and (file_path.parent / (tilt_series + ".mdoc")).is_file()
                     ):
                         newly_completed_series.append(ts)

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -208,7 +208,9 @@ class TomographyContext(Context):
         extract_tilt_angle: Callable[[Path], str],
         extract_tilt_tag: Callable[[Path], str],
         environment: MurfeyInstanceEnvironment | None = None,
+        required_position_files: List[Path] | None = None,
     ) -> List[str]:
+        required_position_files = required_position_files or []
         if not self._extract_tilt_series:
             self._extract_tilt_series = extract_tilt_series
         if not self._extract_tilt_tag:
@@ -424,9 +426,8 @@ class TomographyContext(Context):
                     self._completed_tilt_series.append(tilt_series)
                     newly_completed_series.append(tilt_series)
                 for ts, ta in self._tilt_series.items():
-                    if (
-                        ts not in self._completed_tilt_series
-                        and (file_path.parent / (tilt_series + ".mdoc")).is_file()
+                    if ts not in self._completed_tilt_series and all(
+                        _f.is_file() for _f in required_position_files
                     ):
                         newly_completed_series.append(ts)
                         self._completed_tilt_series.append(ts)
@@ -503,12 +504,16 @@ class TomographyContext(Context):
                 tilt_info_extraction = tomo_tilt_info["5.7"]
         else:
             tilt_info_extraction = tomo_tilt_info["5.7"]
+        tilt_tag = tilt_info_extraction.tag(file_path)
+        tilt_series_num = tilt_info_extraction.series(file_path)
+        tilt_series = f"{tilt_tag}_{tilt_series_num}" if tilt_tag else tilt_series_num
         return self._add_tilt(
             file_path,
             tilt_info_extraction.series,
             tilt_info_extraction.angle,
             tilt_info_extraction.tag,
             environment=environment,
+            required_position_files=[file_path.parent / (tilt_series + ".mdoc")],
         )
 
     def _add_serialem_tilt(

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -427,6 +427,7 @@ class TomographyContext(Context):
                     if (
                         len(ta) >= tilt_series_size
                         and ts not in self._completed_tilt_series
+                        and (file_path.parent / (tilt_series + ".mdoc")).is_file()
                     ):
                         newly_completed_series.append(ts)
                         self._completed_tilt_series.append(ts)

--- a/tests/client/test_context.py
+++ b/tests/client/test_context.py
@@ -11,49 +11,87 @@ def test_tomography_context_initialisation_for_tomo():
 
 def test_tomography_context_add_tomo_tilt(tmp_path):
     context = TomographyContext("tomo")
-    context.post_transfer(tmp_path / "Position_1_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_1_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert context._tilt_series == {"Position_1": [tmp_path / "Position_1_[30.0].tiff"]}
     assert context._last_transferred_file == tmp_path / "Position_1_[30.0].tiff"
-    context.post_transfer(tmp_path / "Position_1_[-30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_1_[-30.0].tiff",
+        role="detector",
+        required_position_files=[],
+    )
     assert not context._completed_tilt_series
-    context.post_transfer(tmp_path / "Position_2_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_2_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert len(context._tilt_series.values()) == 2
     assert context._completed_tilt_series == ["Position_1"]
 
 
 def test_tomography_context_add_tomo_tilt_out_of_order(tmp_path):
     context = TomographyContext("tomo")
-    context.post_transfer(tmp_path / "Position_1_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_1_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert context._tilt_series == {"Position_1": [tmp_path / "Position_1_[30.0].tiff"]}
     assert context._last_transferred_file == tmp_path / "Position_1_[30.0].tiff"
-    context.post_transfer(tmp_path / "Position_1_[-30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_1_[-30.0].tiff",
+        role="detector",
+        required_position_files=[],
+    )
     assert not context._completed_tilt_series
-    context.post_transfer(tmp_path / "Position_2_[-30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_2_[-30.0].tiff",
+        role="detector",
+        required_position_files=[],
+    )
     assert len(context._tilt_series.values()) == 2
     assert not context._completed_tilt_series
-    context.post_transfer(tmp_path / "Position_2_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_2_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert len(context._tilt_series.values()) == 2
     assert not context._completed_tilt_series
-    context.post_transfer(tmp_path / "Position_3_[-30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_3_[-30.0].tiff",
+        role="detector",
+        required_position_files=[],
+    )
     assert len(context._tilt_series.values()) == 3
     assert context._completed_tilt_series == ["Position_1", "Position_2"]
-    context.post_transfer(tmp_path / "Position_3_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_3_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert context._completed_tilt_series == ["Position_1", "Position_2", "Position_3"]
 
 
 def test_tomography_context_add_tomo_tilt_delayed_tilt(tmp_path):
     context = TomographyContext("tomo")
-    context.post_transfer(tmp_path / "Position_1_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_1_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert context._tilt_series == {"Position_1": [tmp_path / "Position_1_[30.0].tiff"]}
     assert context._last_transferred_file == tmp_path / "Position_1_[30.0].tiff"
-    context.post_transfer(tmp_path / "Position_1_[-30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_1_[-30.0].tiff",
+        role="detector",
+        required_position_files=[],
+    )
     assert not context._completed_tilt_series
-    context.post_transfer(tmp_path / "Position_2_[30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_2_[30.0].tiff", role="detector", required_position_files=[]
+    )
     assert len(context._tilt_series.values()) == 2
     assert context._completed_tilt_series == ["Position_1"]
-    context.post_transfer(tmp_path / "Position_2_[-30.0].tiff", role="detector")
+    context.post_transfer(
+        tmp_path / "Position_2_[-30.0].tiff",
+        role="detector",
+        required_position_files=[],
+    )
     new_series = context.post_transfer(
-        tmp_path / "Position_1_[60.0].tiff", role="detector"
+        tmp_path / "Position_1_[60.0].tiff", role="detector", required_position_files=[]
     )
     assert context._completed_tilt_series == ["Position_2", "Position_1"]
     assert new_series == ["Position_1"]


### PR DESCRIPTION
Currently TFS Tomo acquisition software only writes a position mdoc after the full tilt series has been collected so this can be used as a more reliable indicator of tilt series completion