### PR TITLE
Use manual tilt offset from input parameters 

### DIFF
--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -127,7 +127,8 @@ class TomographyContext(Context):
         appid: int,
         mvid: int,
         tilt_angles: List,
-        tilt_offset: Optional[float],
+        manual_tilt_offset: Optional[float],
+        pixel_size: Optional[float],
     ):
         if self._extract_tilt_series and self._extract_tilt_tag:
             tilt_series = (
@@ -165,7 +166,8 @@ class TomographyContext(Context):
                         "autoproc_program_id": appid,
                         "motion_corrected_path": str(motion_corrected_path),
                         "movie_id": mvid,
-                        "tilt_offset": tilt_offset,
+                        "manual_tilt_offset": manual_tilt_offset,
+                        "pixel_size": pixel_size,
                     }
                     requests.post(url, json=series_data)
                     with self._lock:
@@ -495,7 +497,10 @@ class TomographyContext(Context):
                                         ),
                                         file_tilt_list,
                                         environment.data_collection_parameters.get(
-                                            "tilt_offset"
+                                            "manual_tilt_offset"
+                                        ),
+                                        environment.data_collection_parameters.get(
+                                            "pixel_size_on_image"
                                         ),
                                     )
                 if newly_completed_series:
@@ -633,7 +638,7 @@ class TomographyContext(Context):
             metadata["dose_per_frame"] = TUIFormValue(
                 None, top=True, colour="dark_orange"
             )
-            metadata["tilt_offset"] = TUIFormValue(0, top=True)
+            metadata["manual_tilt_offset"] = TUIFormValue(0, top=True)
             metadata.move_to_end("gain_ref", last=False)
             metadata.move_to_end("dose_per_frame", last=False)
             # logger.info(f"Metadata extracted from {metadata_file}: {metadata}")
@@ -655,7 +660,7 @@ class TomographyContext(Context):
         mdoc_metadata["dose_per_frame"] = TUIFormValue(
             None, top=True, colour="dark_orange"
         )
-        mdoc_metadata["tilt_offset"] = TUIFormValue(0, top=True)
+        mdoc_metadata["manual_tilt_offset"] = TUIFormValue(0, top=True)
         mdoc_metadata.move_to_end("gain_ref", last=False)
         mdoc_metadata.move_to_end("dose_per_frame", last=False)
         # logger.info(f"Metadata extracted from {metadata_file}")

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -44,7 +44,8 @@ class MurfeyInstanceEnvironment(BaseModel):
     tilt_angles: Dict[str, List[List[str]]] = {}
     visit: str = ""
     processing_only_mode: bool = False
-    tilt_offset: Optional[float] = None
+    manual_tilt_offset: Optional[float] = None
+    pixel_size_on_image: Optional[float] = None
     gain_ref: Optional[Path] = None
 
     class Config:
@@ -116,6 +117,8 @@ class MurfeyInstanceEnvironment(BaseModel):
                         values["autoproc_program_ids"][k]["em-tomo-align"],
                         v[k][1],
                         file_tilt_list,
+                        values["manual_tilt_offset"],
+                        values["pixel_size_on_image"],
                     )
             else:
                 for k in v.keys():
@@ -142,7 +145,8 @@ class MurfeyInstanceEnvironment(BaseModel):
                             values["autoproc_program_ids"][tilt]["em-tomo-align"],
                             v[k][1],
                             file_tilt_list,
-                            values["tilt_offset"],
+                            values["manual_tilt_offset"],
+                            values["pixel_size_on_image"],
                         )
                     except KeyError:
                         pass

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -44,8 +44,6 @@ class MurfeyInstanceEnvironment(BaseModel):
     tilt_angles: Dict[str, List[List[str]]] = {}
     visit: str = ""
     processing_only_mode: bool = False
-    manual_tilt_offset: Optional[float] = None
-    pixel_size_on_image: Optional[float] = None
     gain_ref: Optional[Path] = None
 
     class Config:
@@ -117,8 +115,8 @@ class MurfeyInstanceEnvironment(BaseModel):
                         values["autoproc_program_ids"][k]["em-tomo-align"],
                         v[k][1],
                         file_tilt_list,
-                        values["manual_tilt_offset"],
-                        values["pixel_size_on_image"],
+                        values["data_collection_parameters"]["manual_tilt_offset"],
+                        values["data_collection_parameters"]["pixel_size_on_image"],
                     )
             else:
                 for k in v.keys():
@@ -145,8 +143,8 @@ class MurfeyInstanceEnvironment(BaseModel):
                             values["autoproc_program_ids"][tilt]["em-tomo-align"],
                             v[k][1],
                             file_tilt_list,
-                            values["manual_tilt_offset"],
-                            values["pixel_size_on_image"],
+                            values["data_collection_parameters"]["manual_tilt_offset"],
+                            values["data_collection_parameters"]["pixel_size_on_image"],
                         )
                     except KeyError:
                         pass

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -484,7 +484,7 @@ class DCParametersTomo(BaseModel):
     image_size_y: int
     pixel_size_on_image: str
     motion_corr_binning: int
-    tilt_offset: float
+    manual_tilt_offset: float
     file_extension: str
     acquisition_software: str
 

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -280,6 +280,8 @@ async def request_tilt_series_alignment(tilt_series: TiltSeries):
             "appid": tilt_series.autoproc_program_id,
             "stack_file": str(stack_file),
             "movie_id": tilt_series.movie_id,
+            "pix_size": tilt_series.pixel_size,
+            "manual_tilt_offset": tilt_series.manual_tilt_offset,
         },
     }
     if _transport_object:

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -64,6 +64,8 @@ class TiltSeries(BaseModel):
     autoproc_program_id: int
     motion_corrected_path: str
     movie_id: int
+    pixel_size: float
+    manual_tilt_offset: int
 
 
 class SuggestedPathParameters(BaseModel):


### PR DESCRIPTION
and pass pixel size to tomo align service.

This means the tilt offset will be taken into account by the tomo_align service, and the pixel size will be scaled and stored in the database as pixel_spacing.
This should fix https://github.com/DiamondLightSource/python-murfey/issues/129
