### PR TITLE
Automatically detect superres data collections and use calibrated pixel sizes

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -103,7 +103,8 @@ class Analyser(Observer):
             ):
                 if self._context:
                     dc_metadata = self._context.gather_metadata(
-                        mdoc_for_reading or transferred_file
+                        mdoc_for_reading or transferred_file,
+                        environment=self._environment,
                     )
                     mdoc_for_reading = None
                 elif transferred_file.suffix == ".mdoc":
@@ -130,7 +131,8 @@ class Analyser(Observer):
                                 dc_metadata = self._context.gather_metadata(
                                     transferred_file.with_suffix(".mdoc")
                                     if self._context._acquisition_software == "serialem"
-                                    else transferred_file.with_suffix(".xml")
+                                    else transferred_file.with_suffix(".xml"),
+                                    environment=self._environment,
                                 )
                             except NotImplementedError:
                                 dc_metadata = {}
@@ -160,7 +162,8 @@ class Analyser(Observer):
                     if self._role == "detector":
                         if not dc_metadata:
                             dc_metadata = self._context.gather_metadata(
-                                transferred_file.with_suffix(".xml")
+                                transferred_file.with_suffix(".xml"),
+                                environment=self._environment,
                             )
                         if not dc_metadata or not self._force_mdoc_metadata:
                             self._unseen_xml.append(transferred_file)
@@ -185,7 +188,8 @@ class Analyser(Observer):
                 ):
                     if not dc_metadata:
                         dc_metadata = self._context.gather_metadata(
-                            transferred_file.with_suffix(".xml")
+                            transferred_file.with_suffix(".xml"),
+                            environment=self._environment,
                         )
                     self.notify({"form": dc_metadata})
 

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -57,7 +57,9 @@ class Context:
     def post_first_transfer(self, transferred_file: Path, role: str = "", **kwargs):
         self.post_transfer(transferred_file, role=role, **kwargs)
 
-    def gather_metadata(self, metadata_file: Path):
+    def gather_metadata(
+        self, metadata_file: Path, environment: MurfeyInstanceEnvironment | None = None
+    ):
         raise NotImplementedError(
             f"gather_metadata must be declared in derived class to be used: {self}"
         )

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -667,7 +667,7 @@ class TomographyContext(Context):
             )
             if ps_from_mag:
                 mdoc_metadata["pixel_size_on_image"] = TUIFormValue(
-                    float(mdoc_data["PixelSpacing"]) * 1e-10 / binning_factor
+                    float(ps_from_mag) * 1e-10 / binning_factor
                 )
         if mdoc_metadata.get("pixel_size_on_image") is None:
             mdoc_metadata["pixel_size_on_image"] = TUIFormValue(

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -681,5 +681,4 @@ class TomographyContext(Context):
         mdoc_metadata["tilt_offset"] = TUIFormValue(0, top=True)
         mdoc_metadata.move_to_end("gain_ref", last=False)
         mdoc_metadata.move_to_end("dose_per_frame", last=False)
-        # logger.info(f"Metadata extracted from {metadata_file}")
         return mdoc_metadata

--- a/src/murfey/client/context.py
+++ b/src/murfey/client/context.py
@@ -652,10 +652,14 @@ class TomographyContext(Context):
         mdoc_metadata["image_size_x"] = TUIFormValue(int(mdoc_data["ImageSize"][0]))
         mdoc_metadata["image_size_y"] = TUIFormValue(int(mdoc_data["ImageSize"][1]))
         mdoc_metadata["magnification"] = TUIFormValue(int(mdoc_data["Magnification"]))
+        superres_binning = int(mdoc_data["Binning"])
+        binning_factor = 1
         if environment:
             server_config = requests.get(
                 f"{str(environment.url.geturl())}/machine/"
             ).json()
+            if server_config.get("superres") and superres_binning == 1:
+                binning_factor = 2
             ps_from_mag = (
                 server_config.get("calibrations", {})
                 .get("magnification", {})
@@ -663,13 +667,13 @@ class TomographyContext(Context):
             )
             if ps_from_mag:
                 mdoc_metadata["pixel_size_on_image"] = TUIFormValue(
-                    float(mdoc_data["PixelSpacing"]) * 1e-10
+                    float(mdoc_data["PixelSpacing"]) * 1e-10 / binning_factor
                 )
         if mdoc_metadata.get("pixel_size_on_image") is None:
             mdoc_metadata["pixel_size_on_image"] = TUIFormValue(
-                float(mdoc_data["PixelSpacing"]) * 1e-10
+                float(mdoc_data["PixelSpacing"]) * 1e-10 / binning_factor
             )
-        mdoc_metadata["motion_corr_binning"] = TUIFormValue(1)
+        mdoc_metadata["motion_corr_binning"] = TUIFormValue(binning_factor)
         mdoc_metadata["gain_ref"] = TUIFormValue(None, top=True)
         mdoc_metadata["dose_per_frame"] = TUIFormValue(
             None, top=True, colour="dark_orange"

--- a/src/murfey/server/config.py
+++ b/src/murfey/server/config.py
@@ -17,6 +17,7 @@ class MachineConfig(BaseModel):
     gain_reference_directory: Optional[Path] = None
     processed_directory_name: str = "processed"
     feedback_queue: str = "murfey_feedback"
+    superres: bool = False
 
 
 def from_file(config_file_path: Path, microscope: str) -> MachineConfig:

--- a/src/murfey/server/config.py
+++ b/src/murfey/server/config.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 class MachineConfig(BaseModel):
     acquisition_software: List[str]
-    calibrations: Dict[str, Union[dict, float]]
+    calibrations: Dict[str, Dict[str, Union[dict, float]]]
     data_directories: Dict[Path, str]
     rsync_basepath: Path
     software_versions: Dict[str, str] = {}


### PR DESCRIPTION
If the detector is capable of collecting in superresolution then `superres` should be set to `True` in the machine configuration. If the data are then unbinned (as determined from mdoc files) the data has been collected in superresolution. 

Allow calibrated pixel sizes based on magnification to be used rather than the pixel size direct from the mdoc.