### PR TITLE
Add path_pattern and remove movie_id fields 

### DIFF
--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -288,12 +288,11 @@ async def request_tilt_series_alignment(tilt_series: TiltSeries):
     zocalo_message = {
         "recipes": ["em-tomo-align"],
         "parameters": {
-            # "ispyb_process": tilt_series.processing_job, #
             "input_file_list": tilt_series.file_tilt_list,
+            "path_pattern": "",  # blank for now so that it works with the tomo_align service changes
             "dcid": tilt_series.dcid,
             "appid": tilt_series.autoproc_program_id,
             "stack_file": str(stack_file),
-            "movie_id": tilt_series.movie_id,
             "pix_size": tilt_series.pixel_size,
             "manual_tilt_offset": tilt_series.manual_tilt_offset,
         },


### PR DESCRIPTION
for the message sent to alignment.
I think the other movie_id references are okay to remain.