### PR TITLE
Separate client & server in dev-portal

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,23 +1,53 @@
 apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: murfey
+  title: Murfey
+  description: A client-server architecture hauling Cryo-EM data around systems and triggering processing
+spec:
+  owner: user:kif41228
+
+---
+
+apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
-  name: Murfey
-  title: Murfey
-  description: Client-Server architecture hauling Cryo-EM data around systems and triggering processing
+  name: murfey-server
+  title: Murfey Server
+  description: A server allowing for the monitoring of Cryo-EM data transfer from microscope systems and triggering relevant processing
   annotations:
     github.com/project-slug: DiamondLightSouce/python-murfey
 spec:
-  type: other
+  type: service
   lifecycle: production
   owner: user:kif41228
   providesApis:
-    - restapi
+    - murfey-rest
+
 ---
+
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: murfey-client
+  title: Murfey Client
+  description: A client for automated data transfer and Cryo-EM metadata extraction from EM systems
+  annotations:
+    github.com/project-slug: DiamondLightSouce/python-murfey
+spec:
+  type: user-interface
+  lifecycle: production
+  owner: user:kif41228
+  consumesApis:
+    - murfey-rest
+
+---
+
 apiVersion: backstage.io/v1alpha1
 kind: API
 metadata:
-  name: restapi
-  title: restapi
+  name: murfey-rest
+  title: Murfey Rest API
   description: REST API registering data collections and requesting processing
 spec:
   type: openapi


### PR DESCRIPTION
Hi Dan,

Cheers for adding an entity descriptor for the developer portal! I thought it might be nice to split the entity into a client & server component to reflect the real application. I've edited the `catalog-info.yaml` file with what I think is right, but I'm not 100% sure I've captured things correctly, any chance you could answer the following?
- Is Murfey is an entire system unto itself? If so it would be good to add a `system` component representing it, if not it's probably best left out. 
- Is the client is a library or something else? It reads as if it has a web interface which I guess would make it a website under the [common component types](https://diamondlightsource.github.io/developer-portal/user/references/common-component-types/) - though if you have some other way of describing it we can expand that list.