### PR TITLE
Make transfer monitoring through Prometheus more accurate

### DIFF
--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -306,6 +306,33 @@ class MurfeyTUI(App):
         }
         requests.post(url, json=data)
 
+    # Prometheus can handle higher traffic so update for every transferred file rather
+    # than batching as we do for the Murfey database updates in _increment_transferred_files
+    def _increment_transferred_files_prometheus(
+        self, update: RSyncerUpdate, source: str, destination: str
+    ):
+        if update.outcome is TransferResult.SUCCESS:
+            url = f"{str(self._url.geturl())}/visits/{str(self._visit)}/increment_rsync_transferred_files_prometheus"
+            data_files = (
+                [update]
+                if update.file_path.suffix in self._data_suffixes
+                and any(
+                    substring in update.file_path.name
+                    for substring in self._data_substrings
+                )
+                else []
+            )
+            data = {
+                "source": source,
+                "destination": destination,
+                "client_id": self._environment.client_id,
+                "increment_count": 1,
+                "bytes": update.file_size,
+                "increment_data_count": len(data_files),
+                "data_bytes": sum(f.file_size for f in data_files),
+            }
+            requests.post(url, json=data)
+
     def _increment_transferred_files(
         self, updates: List[RSyncerUpdate], source: str, destination: str
     ):

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -226,6 +226,13 @@ class MurfeyTUI(App):
         self.rsync_processes[source].subscribe(rsync_result)
         self.rsync_processes[source].subscribe(
             partial(
+                self._increment_transferred_files_prometheus,
+                destination=destination,
+                source=str(source),
+            )
+        )
+        self.rsync_processes[source].subscribe(
+            partial(
                 self._increment_transferred_files,
                 destination=destination,
                 source=str(source),

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -259,6 +259,12 @@ def increment_rsync_transferred_files(
     db.add(rsync_instance)
     db.commit()
     db.close()
+
+
+@router.post("/visits/{visit_name}/increment_rsync_transferred_files_prometheus")
+def increment_rsync_transferred_files_prometheus(
+    visit_name: str, rsyncer_info: RsyncerInfo, db=murfey_db
+):
     prom.transferred_files.labels(rsync_source=rsyncer_info.source).inc(
         rsyncer_info.increment_count
     )

--- a/src/murfey/server/demo_api.py
+++ b/src/murfey/server/demo_api.py
@@ -224,11 +224,23 @@ def increment_rsync_transferred_files(
     rsync_instance.files_transferred += 1
     db.add(rsync_instance)
     db.commit()
+
+
+@router.post("/visits/{visit_name}/increment_rsync_transferred_files_prometheus")
+def increment_rsync_transferred_files_prometheus(
+    visit_name: str, rsyncer_info: RsyncerInfo, db=murfey_db
+):
     prom.transferred_files.labels(rsync_source=rsyncer_info.source).inc(
         rsyncer_info.increment_count
     )
     prom.transferred_files_bytes.labels(rsync_source=rsyncer_info.source).inc(
         rsyncer_info.bytes
+    )
+    prom.transferred_data_files.labels(rsync_source=rsyncer_info.source).inc(
+        rsyncer_info.increment_data_count
+    )
+    prom.transferred_data_files_bytes.labels(rsync_source=rsyncer_info.source).inc(
+        rsyncer_info.data_bytes
     )
 
 


### PR DESCRIPTION
Increment the transferred file count and volume on transfer of every individual file in Prometheus. This wasn't done before because of concerns over large numbers of rapid connections to the Murfey database. We are keeping the transfer registration in the Murfey database batched but hopefully Prometheus can handle the throughput better. Closes #193 