### PR TITLE
Change the tomography alignment request methods to avoid cases of duplication

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -564,16 +564,8 @@ class TomographyContext(Context):
                     tilt_series,
                     required_position_files or [],
                     file_transferred_to,
-                    rsync_source=source,
                     environment=environment,
                 )
-
-        if res and environment:
-            complete_url = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.client_id}/completed_tilt_series"
-            capture_post(
-                complete_url,
-                json={"tags": res, "source": str(file_path.parent)},
-            )
 
         if environment:
             tilt_url = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.client_id}/tilt"
@@ -645,7 +637,6 @@ class TomographyContext(Context):
                     tilt_series,
                     required_position_files or [],
                     file_transferred_to,
-                    rsync_source=source,
                     environment=environment,
                 )
         self._last_transferred_file = file_path
@@ -656,14 +647,13 @@ class TomographyContext(Context):
         tilt_series: str,
         required_position_files: List[Path],
         file_transferred_to: Path | None,
-        rsync_source: Path,
         environment: MurfeyInstanceEnvironment | None = None,
-    ):
-        newly_completed_series = []
+    ) -> List[str]:
+        newly_completed_series: List[str] = []
         if self._tilt_series:
             tilt_series_size = max(len(ts) for ts in self._tilt_series.values())
         else:
-            tilt_series_size = 0
+            return newly_completed_series
         this_tilt_series_size = len(self._tilt_series.get(tilt_series, []))
         tilt_series_size_check = (
             (this_tilt_series_size == self._tilt_series_sizes.get(tilt_series))
@@ -673,7 +663,7 @@ class TomographyContext(Context):
         if tilt_series_size_check and not required_position_files:
             if tilt_series not in self._completed_tilt_series:
                 self._completed_tilt_series.append(tilt_series)
-            newly_completed_series.append(tilt_series)
+                newly_completed_series.append(tilt_series)
         for ts, ta in self._tilt_series.items():
             required_position_files_check = (
                 all(_f.is_file() for _f in required_position_files)
@@ -739,19 +729,6 @@ class TomographyContext(Context):
                                     "pixel_size_on_image"
                                 ),
                             )
-        if newly_completed_series:
-            logger.info(
-                f"The following tilt series are considered complete: {newly_completed_series}"
-            )
-            if environment:
-                completed_tilt_endpoint = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.client_id}/completed_tilt_series"
-                requests.post(
-                    completed_tilt_endpoint,
-                    json={
-                        "tilt_series": newly_completed_series,
-                        "rsync_source": str(rsync_source),
-                    },
-                )
         return newly_completed_series
 
     def _add_tomo_tilt(
@@ -870,14 +847,23 @@ class TomographyContext(Context):
                             self._file_transferred_to(
                                 environment, source, transferred_file
                             ),
-                            rsync_source=transferred_file.parent,
                             environment=environment,
                         )
         if completed_tilts and environment:
+            logger.info(
+                f"The following tilt series are considered complete: {completed_tilts} "
+                f"after {transferred_file}"
+            )
             complete_url = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.client_id}/completed_tilt_series"
             capture_post(
                 complete_url,
-                json={"tags": completed_tilts, "source": str(transferred_file.parent)},
+                json={
+                    "tags": completed_tilts,
+                    "source": str(transferred_file.parent),
+                    "tilt_series_lengths": [
+                        len(self._tilt_series.get(ts, [])) for ts in completed_tilts
+                    ],
+                },
             )
         return completed_tilts
 

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -436,6 +436,13 @@ class TomographyContext(Context):
                 f"Tilt series {tilt_series} was previously thought complete but now {file_path} has been seen"
             )
             self._completed_tilt_series.remove(tilt_series)
+            rerun_url = f"{str(environment.url.geturl())}/visits/{environment.visit}/rerun_tilt_series"
+            rerun_data = {
+                "client_id": environment.client_id,
+                "tag": tilt_series,
+                "source": str(file_path.parent),
+            }
+            capture_post(rerun_url, json=rerun_data)
             if tilt_series in self._aligned_tilt_series:
                 with self._lock:
                     self._aligned_tilt_series.remove(tilt_series)

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -627,25 +627,6 @@ class TomographyContext(Context):
             }
             capture_post(preproc_url, json=preproc_data)
 
-        if self._last_transferred_file:
-            last_tilt_series = (
-                f"{extract_tilt_tag(self._last_transferred_file)}_{extract_tilt_series(self._last_transferred_file)}"
-                if extract_tilt_tag(self._last_transferred_file)
-                else extract_tilt_series(self._last_transferred_file)
-            )
-            last_tilt_angle = extract_tilt_angle(self._last_transferred_file)
-            self._last_transferred_file = file_path
-            if (
-                last_tilt_series != tilt_series
-                and last_tilt_angle != tilt_angle
-                or self._tilt_series_sizes.get(tilt_series)
-            ) or self._completed_tilt_series:
-                return self._check_tilt_series(
-                    tilt_series,
-                    required_position_files or [],
-                    file_transferred_to,
-                    environment=environment,
-                )
         self._last_transferred_file = file_path
         return res
 

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2086,8 +2086,13 @@ def feedback_callback(header: dict, message: dict) -> None:
             relevant_tilt.motion_corrected = True
             murfey_db.add(relevant_tilt)
             murfey_db.commit()
-            murfey_db.close()
-            if check_tilt_series_mc(relevant_tilt_series.id):
+            if (
+                check_tilt_series_mc(relevant_tilt_series.id)
+                and not relevant_tilt_series.processing_requested
+            ):
+                relevant_tilt_series.processing_requested = True
+                murfey_db.add(relevant_tilt_series)
+
                 machine_config = get_machine_config()
                 tilts = get_all_tilts(relevant_tilt_series.id)
                 ids = get_job_ids(relevant_tilt_series.id, message["program_id"])
@@ -2125,6 +2130,8 @@ def feedback_callback(header: dict, message: dict) -> None:
                         f"No transport object found. Zocalo message would be {zocalo_message}"
                     )
 
+            murfey_db.commit()
+            murfey_db.close()
             if _transport_object:
                 _transport_object.transport.ack(header)
             return None

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -106,7 +106,10 @@ def check_tilt_series_mc(tilt_series_id: int) -> bool:
         .where(db.Tilt.tilt_series_id == db.TiltSeries.id)
         .where(db.TiltSeries.id == tilt_series_id)
     ).all()
-    return all(r[0].motion_corrected for r in results) and results[0][1].complete
+    return (
+        all(r[0].motion_corrected for r in results)
+        and len(results) == results[0][1].tilt_series_length
+    )
 
 
 def get_all_tilts(tilt_series_id: int) -> List[str]:

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -597,7 +597,7 @@ def register_completed_tilt_series(
         .where(TiltSeries.rsync_source == tilt_series_group.source)
     ).all()
     for ts in tilt_series_db:
-        ts_index = tilt_series_group.tags == ts.tag
+        ts_index = tilt_series_group.tags.index(ts.tag)
         ts.tilt_series_length = tilt_series_group.tilt_series_lengths[ts_index]
         db.add(ts)
     db.commit()

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -597,7 +597,8 @@ def register_completed_tilt_series(
         .where(TiltSeries.rsync_source == tilt_series_group.source)
     ).all()
     for ts in tilt_series_db:
-        ts.complete = True
+        ts_index = tilt_series_group.tags == ts.tag
+        ts.tilt_series_length = tilt_series_group.tilt_series_lengths[ts_index]
         db.add(ts)
     db.commit()
     for ts in tilt_series_db:

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -601,7 +601,10 @@ def register_completed_tilt_series(
         db.add(ts)
     db.commit()
     for ts in tilt_series_db:
-        if check_tilt_series_mc(ts.id):
+        if check_tilt_series_mc(ts.id) and not ts.processing_requested:
+            ts.processing_requested = True
+            db.add(ts)
+
             collected_ids = db.exec(
                 select(
                     DataCollectionGroup, DataCollection, ProcessingJob, AutoProcProgram
@@ -660,6 +663,7 @@ def register_completed_tilt_series(
                 log.info(
                     f"No transport object found. Zocalo message would be {zocalo_message}"
                 )
+    db.commit()
 
 
 @router.get("/clients/{client_id}/tilt_series/{tilt_series_tag}/tilts")

--- a/src/murfey/server/demo_api.py
+++ b/src/murfey/server/demo_api.py
@@ -82,7 +82,6 @@ from murfey.util.models import (
     TiltInfo,
     TiltSeriesGroupInfo,
     TiltSeriesInfo,
-    TiltSeriesProcessingDetails,
     Visit,
 )
 from murfey.util.spa_params import default_spa_parameters
@@ -1031,22 +1030,6 @@ async def request_tomography_preprocessing(
         db.commit()
         db.close()
     return proc_file
-
-
-@router.post("/visits/{visit_name}/align")
-async def request_tilt_series_alignment(tilt_series: TiltSeriesProcessingDetails):
-    stack_file = (
-        Path(tilt_series.motion_corrected_path).parents[1]
-        / "align_output"
-        / f"aligned_file_{tilt_series.name}.mrc"
-    )
-    if not stack_file.parent.exists():
-        stack_file.parent.mkdir(parents=True)
-    await ws.manager.broadcast(
-        f"Processing requested for tilt series {tilt_series.name}"
-    )
-    stack_file.touch()
-    return tilt_series
 
 
 @router.get("/version")

--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -49,7 +49,7 @@ class TiltSeries(SQLModel, table=True):  # type: ignore
     tag: str
     rsync_source: str
     session_id: int = Field(foreign_key="session.id")
-    tilt_series_length: int
+    tilt_series_length: int = -1
     processing_requested: bool = False
     session: Optional[Session] = Relationship(back_populates="tilt_series")
     tilts: List["Tilt"] = Relationship(

--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -49,7 +49,7 @@ class TiltSeries(SQLModel, table=True):  # type: ignore
     tag: str
     rsync_source: str
     session_id: int = Field(foreign_key="session.id")
-    complete: bool = False
+    tilt_series_length: int
     processing_requested: bool = False
     session: Optional[Session] = Relationship(back_populates="tilt_series")
     tilts: List["Tilt"] = Relationship(

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -139,6 +139,7 @@ class TiltSeriesInfo(BaseModel):
 class TiltSeriesGroupInfo(BaseModel):
     tags: List[str]
     source: str
+    tilt_series_lengths: List[int]
 
 
 class CompletedTiltSeries(BaseModel):

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -146,18 +146,6 @@ class CompletedTiltSeries(BaseModel):
     rsync_source: str
 
 
-class TiltSeriesProcessingDetails(BaseModel):
-    name: str
-    file_tilt_list: str
-    dcid: int
-    processing_job: int
-    autoproc_program_id: int
-    motion_corrected_path: str
-    movie_id: int
-    pixel_size: float
-    manual_tilt_offset: int
-
-
 class SuggestedPathParameters(BaseModel):
     base_path: Path
     touch: bool = False


### PR DESCRIPTION
This implements a check that processing has not already been requested, and also checks the length of the tilt list after motion correction.

Closes #257 