### PR TITLE
Updated CI/CD environment

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -14,7 +14,7 @@ trigger:
 resources:
   containers:
     - container: mariadb
-      image: mariadb:latest # 10.8 (released 2023-06-02)
+      image: mariadb:11.3.2 # released 2024-05-06 # 10.8 # released 2023-06-02
       # Pulls image from DockerHub
       # Docker images: https://hub.docker.com/_/mariadb
       # 10.8: https://hub.docker.com/layers/library/mariadb/10.8/images/sha256-2c79abca2711c7e7fe4ae21864a29544a8404dfb519973fa6f4caebd5445f66b?context=explore

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,5 +1,7 @@
 variables:
-  DATABASE_SCHEMA: 1.28.0
+  DATABASE_SCHEMA: 4.1.0 # 1.28.0 # released 2021-11-23
+  # This is really old. Current database schema is v4.1.0 (released 2024-03-26)
+  # GitHub versions: https://github.com/DiamondLightSource/ispyb-database/tags
 
 trigger:
   branches:
@@ -12,7 +14,9 @@ trigger:
 resources:
   containers:
     - container: mariadb
-      image: mariadb:10.8
+      image: mariadb:11.4 # 10.8
+      # Where does Azure get this from? DockerHub? 10.8 is not visible on DockerHub.
+      # Docker versions: https://hub.docker.com/_/mariadb
       env:
         MYSQL_DATABASE: ispybtest
         MYSQL_ROOT_PASSWORD: mysql_root_pwd

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -14,9 +14,10 @@ trigger:
 resources:
   containers:
     - container: mariadb
-      image: mariadb:11.4 # 10.8
-      # Where does Azure get this from? DockerHub? 10.8 is not visible on DockerHub.
-      # Docker versions: https://hub.docker.com/_/mariadb
+      image: mariadb:latest # 10.8 (released 2023-06-02)
+      # Pulls image from DockerHub
+      # Docker images: https://hub.docker.com/_/mariadb
+      # 10.8: https://hub.docker.com/layers/library/mariadb/10.8/images/sha256-2c79abca2711c7e7fe4ae21864a29544a8404dfb519973fa6f4caebd5445f66b?context=explore
       env:
         MYSQL_DATABASE: ispybtest
         MYSQL_ROOT_PASSWORD: mysql_root_pwd

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -1,7 +1,9 @@
 variables:
-  DATABASE_SCHEMA: 4.1.0 # 1.28.0 # released 2021-11-23
-  # This is really old. Current database schema is v4.1.0 (released 2024-03-26)
-  # GitHub versions: https://github.com/DiamondLightSource/ispyb-database/tags
+  DATABASE_SCHEMA: 4.1.0 # released 2024-03-26
+  # Installs from GitHub
+  # Versions: https://github.com/DiamondLightSource/ispyb-database/tags
+  # Previous version(s):
+  # 1.28.0 # released 2021-11-23
 
 trigger:
   branches:
@@ -14,10 +16,11 @@ trigger:
 resources:
   containers:
     - container: mariadb
-      image: mariadb:11.3.2 # released 2024-05-06 # 10.8 # released 2023-06-02
+      image: mariadb:11.3.2 # released 2024-05-06
       # Pulls image from DockerHub
       # Docker images: https://hub.docker.com/_/mariadb
-      # 10.8: https://hub.docker.com/layers/library/mariadb/10.8/images/sha256-2c79abca2711c7e7fe4ae21864a29544a8404dfb519973fa6f4caebd5445f66b?context=explore
+      # Previous version(s):
+      # 10.8 # released 2023-06-02 # https://hub.docker.com/layers/library/mariadb/10.8/images/sha256-2c79abca2711c7e7fe4ae21864a29544a8404dfb519973fa6f4caebd5445f66b?context=explore
       env:
         MYSQL_DATABASE: ispybtest
         MYSQL_ROOT_PASSWORD: mysql_root_pwd

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,3 +1,5 @@
+# Contains tasks to be repeated when testing for the different Python versions listed
+# in the "Run unit tests" stage in .azure-pipelines/azure-pipelines.yml
 steps:
   - checkout: none
 
@@ -6,7 +8,7 @@ steps:
       mkdir rabbitmq-docker && cd rabbitmq-docker
 
       cat <<EOF >rabbitmq.conf
-      # allowing remote connections for default user is highly discouraged
+      # Allowing remote connections for default user is highly discouraged
       # as it dramatically decreases the security of the system. Delete the user
       # instead and create a new one with generated secure credentials.
       loopback_users = none
@@ -44,7 +46,7 @@ steps:
 
   - script: |
       set -eux
-      pip install --disable-pip-version-check -e "$(Pipeline.Workspace)/src"[cicd,clem,client,server,developer]
+      pip install --disable-pip-version-check -e "$(Pipeline.Workspace)/src"[cicd,client,server,developer]
     displayName: Install package
 
   - script: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,11 +39,6 @@ dependencies = [
 cicd = [
     "pytest-cov", # Used by Azure Pipelines for PyTest coverage reports
 ]
-clem = [
-    # "matplotlib", # For visual statistical analysis of images
-    "readlif", # cryo-CLEM; open LIF files
-    "tifffile", # cryo-CLEM; for saving to to TIFF files
-]
 client = [
     "procrunner",
     "textual==0.42.0",
@@ -57,11 +52,13 @@ developer = [
     "pytest", # Test code functionality
 ]
 server = [
+    # "matplotlib", # For visual statistical analysis of images
+    "readlif", # cryo-CLEM; open LIF files
+    "tifffile", # cryo-CLEM; for saving to to TIFF files
     "cryptography",
     "fastapi",
-    "ispyb",
+    "ispyb", # Responsible for setting requirements for SQLAlchemy (<2; v10.0.0) and mysql-connector-python (>=8.0.32; v10.0.0)
     "jinja2",
-    "mysql-connector-python<=8.0.29", # ispyb 8.0.0 requires ==8.0.29
     "numpy",
     "packaging",
     "pillow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,18 +53,18 @@ developer = [
 ]
 server = [
     # "matplotlib", # For visual statistical analysis of images
-    "readlif", # cryo-CLEM; open LIF files
-    "tifffile", # cryo-CLEM; for saving to to TIFF files
     "cryptography",
     "fastapi",
-    "ispyb", # Responsible for setting requirements for SQLAlchemy (<2; v10.0.0) and mysql-connector-python (>=8.0.32; v10.0.0)
+    "ispyb", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
     "jinja2",
     "numpy",
     "packaging",
     "pillow",
     "prometheus_client",
+    "readlif", # Specific to cryo-CLEM workflow
     "sqlmodel",
     "stomp-py<=8.1.0", # 8.1.1 (released 2024-04-06) doesn't work with our project
+    "tifffile", # Specific to cryo-CLEM workflow
     "uvicorn[standard]",
     "zocalo",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ server = [
     # "matplotlib", # For visual statistical analysis of images
     "cryptography",
     "fastapi",
-    "ispyb<=8.0.1", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
+    "ispyb", # Responsible for setting requirements for SQLAlchemy and mysql-connector-python; v10.0.0: sqlalchemy <2, mysql-connector-python >=8.0.32
     "jinja2",
     "numpy",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ server = [
     # "matplotlib", # For visual statistical analysis of images
     "cryptography",
     "fastapi",
-    "ispyb", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
+    "ispyb<=8.0.0", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
     "jinja2",
     "numpy",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ server = [
     # "matplotlib", # For visual statistical analysis of images
     "cryptography",
     "fastapi",
-    "ispyb<=8.0.0", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
+    "ispyb<=9.0.0", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
     "jinja2",
     "numpy",
     "packaging",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ server = [
     # "matplotlib", # For visual statistical analysis of images
     "cryptography",
     "fastapi",
-    "ispyb<=9.0.0", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
+    "ispyb<=8.0.1", # Responsible for setting requirements for SQLAlchemy (<2) and mysql-connector-python (>=8.0.32); currently running v10.0.0
     "jinja2",
     "numpy",
     "packaging",


### PR DESCRIPTION
Resolves issue #272 and #256.

Changes:
- Moved `[clem]` dependencies under `[server]` in `pyproject.toml`, now that their use case is more clear.
- Removed `mysql-connector-python` as an explicit dependency; it will be controlled by `ispyb`.
- Updated `ispyb-database` and `mariadb` versions used by Azure Pipelines to latest stable ones. These are now compatible with `ispyb v10.0.0`

`pip install` Verification for Python Versions:
- [x] Python 3.9
- [x] Python 3.10
- [x] Python 3.11
- [x] Python 3.12