### PR TITLE
Improve upstream download speed

### DIFF
--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -776,12 +776,12 @@ class UpstreamDownloads(Screen):
             upstream_tiff_paths = upstream_tiff_paths_response.json()
             for tp in upstream_tiff_paths:
                 (download_dir / tp).parent.mkdir(exist_ok=True, parents=True)
+                stream_response = requests.get(
+                    f"{self.app._environment.url.geturl()}/visits/{event.button.label}/upstream_tiff/{tp}",
+                    stream=True,
+                )
                 with open(download_dir / tp, "wb") as utiff:
-                    stream_response = requests.get(
-                        f"{self.app._environment.url.geturl()}/visits/{event.button.label}/upstream_tiff/{tp}",
-                        stream=True,
-                    )
-                    for chunk in stream_response.iter_content():
+                    for chunk in stream_response.iter_content(chunk_size=32 * 1024**2):
                         utiff.write(chunk)
         self.app.pop_screen()
 

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -10,7 +10,7 @@ from typing import Dict, List, Optional
 import packaging.version
 import sqlalchemy
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from ispyb.sqlalchemy import AutoProcProgram as ISPyBAutoProcProgram
 from ispyb.sqlalchemy import (
     BLSample,
@@ -1640,12 +1640,4 @@ async def get_tiff(visit_name: str, tiff_path: str):
 
     tiff_path = "/".join(secure_filename(p) for p in tiff_path.split("/"))
 
-    def iterfile():
-        with open(processed_dir / tiff_path, mode="rb") as f:
-            yield from f
-
-    return StreamingResponse(
-        iterfile(),
-        media_type="image/tiff",
-        headers={"Content-Disposition": f"attachment; filename={Path(tiff_path).name}"},
-    )
+    return FileResponse(path=processed_dir / tiff_path)

--- a/src/murfey/server/demo_api.py
+++ b/src/murfey/server/demo_api.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Optional
 import packaging.version
 import sqlalchemy
 from fastapi import APIRouter, Request
-from fastapi.responses import FileResponse, HTMLResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from ispyb.sqlalchemy import BLSession
 from PIL import Image
 from pydantic import BaseModel, BaseSettings
@@ -1475,12 +1475,4 @@ async def get_tiff(visit_name: str, tiff_path: str):
 
     tiff_path = "/".join(secure_filename(p) for p in tiff_path.split("/"))
 
-    def iterfile():
-        with open(processed_dir / tiff_path, mode="rb") as f:
-            yield from f
-
-    return StreamingResponse(
-        iterfile(),
-        media_type="image/tiff",
-        headers={"Content-Disposition": f"attachment; filename={Path(tiff_path).name}"},
-    )
+    return FileResponse(path=processed_dir / tiff_path)


### PR DESCRIPTION
Use `FileResponse` for asynchronous serving of individual TIFF files and write in 32 MB chunks on the client side