### PR TITLE
Always update the tilt series length in the database after an mdoc

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -837,17 +837,18 @@ class TomographyContext(Context):
                         )
 
                     # Always update the tilt series length in the database after an mdoc
-                    length_url = f"{str(environment.url.geturl())}/clients/{environment.client_id}/tilt_series_length"
-                    capture_post(
-                        length_url,
-                        json={
-                            "tags": [tilt_series],
-                            "source": str(transferred_file.parent),
-                            "tilt_series_lengths": [
-                                self._tilt_series_sizes[tilt_series]
-                            ],
-                        },
-                    )
+                    if environment.murfey_session is not None:
+                        length_url = f"{str(environment.url.geturl())}/sessions/{environment.murfey_session}/tilt_series_length"
+                        capture_post(
+                            length_url,
+                            json={
+                                "tags": [tilt_series],
+                                "source": str(transferred_file.parent),
+                                "tilt_series_lengths": [
+                                    self._tilt_series_sizes[tilt_series]
+                                ],
+                            },
+                        )
 
         if completed_tilts and environment:
             logger.info(

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -835,6 +835,20 @@ class TomographyContext(Context):
                             ),
                             environment=environment,
                         )
+
+                    # Always update the tilt series length in the database after an mdoc
+                    length_url = f"{str(environment.url.geturl())}/clients/{environment.client_id}/tilt_series_length"
+                    capture_post(
+                        length_url,
+                        json={
+                            "tags": [tilt_series],
+                            "source": str(transferred_file.parent),
+                            "tilt_series_lengths": [
+                                self._tilt_series_sizes[tilt_series]
+                            ],
+                        },
+                    )
+
         if completed_tilts and environment:
             logger.info(
                 f"The following tilt series are considered complete: {completed_tilts} "

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -635,6 +635,7 @@ def register_completed_tilt_series(
                     DataCollectionGroup, DataCollection, ProcessingJob, AutoProcProgram
                 )
                 .where(DataCollectionGroup.session_id == session_id)
+                .where(DataCollectionGroup.tag == tilt_series_group.source)
                 .where(DataCollection.tag == ts.tag)
                 .where(DataCollection.dcg_id == DataCollectionGroup.id)
                 .where(ProcessingJob.dc_id == DataCollection.id)

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -574,19 +574,12 @@ def register_tilt_series(
     db.commit()
 
 
-@router.post("/clients/{client_id}/tilt_series_length")
+@router.post("/sessions/{session_id}/tilt_series_length")
 def register_tilt_series_length(
-    client_id: int,
+    session_id: int,
     tilt_series_group: TiltSeriesGroupInfo,
     db=murfey_db,
 ):
-    session_id = (
-        db.exec(
-            select(ClientEnvironment).where(ClientEnvironment.client_id == client_id)
-        )
-        .one()
-        .session_id
-    )
     tilt_series_db = db.exec(
         select(TiltSeries)
         .where(col(TiltSeries.tag).in_(tilt_series_group.tags))

--- a/src/murfey/server/api.py
+++ b/src/murfey/server/api.py
@@ -574,6 +574,32 @@ def register_tilt_series(
     db.commit()
 
 
+@router.post("/clients/{client_id}/tilt_series_length")
+def register_tilt_series_length(
+    client_id: int,
+    tilt_series_group: TiltSeriesGroupInfo,
+    db=murfey_db,
+):
+    session_id = (
+        db.exec(
+            select(ClientEnvironment).where(ClientEnvironment.client_id == client_id)
+        )
+        .one()
+        .session_id
+    )
+    tilt_series_db = db.exec(
+        select(TiltSeries)
+        .where(col(TiltSeries.tag).in_(tilt_series_group.tags))
+        .where(TiltSeries.session_id == session_id)
+        .where(TiltSeries.rsync_source == tilt_series_group.source)
+    ).all()
+    for ts in tilt_series_db:
+        ts_index = tilt_series_group.tags.index(ts.tag)
+        ts.tilt_series_length = tilt_series_group.tilt_series_lengths[ts_index]
+        db.add(ts)
+    db.commit()
+
+
 @router.post("/visits/{visit_name}/{client_id}/completed_tilt_series")
 def register_completed_tilt_series(
     visit_name: str,


### PR DESCRIPTION
Tomogram alignment sometimes isn't requested as the database doesn't have a tilt series length. This happens if an mdoc is seen before all the tilts. To solve this, always insert tilt series length into the database when an mdoc is seen.