### PR TITLE
Try and handle the case where users enter their own tomogram names

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -87,7 +87,7 @@ def _get_tilt_series_v5_12(p: Path) -> str:
     angle_idx = _find_angle_index(split_name)
     if split_name[angle_idx - 2].isnumeric():
         return split_name[angle_idx - 2]
-    return "0"
+    return ""
 
 
 def _get_tilt_angle_v5_12(p: Path) -> str:
@@ -122,6 +122,8 @@ tomo_tilt_info = {
 def _construct_tilt_series_name(
     tilt_tag: str, tilt_series: str, file_path: Path
 ) -> str:
+    if not tilt_series:
+        return tilt_tag
     if tilt_tag:
         if f"{tilt_tag}_{tilt_series}" in file_path.name:
             return f"{tilt_tag}_{tilt_series}"
@@ -557,11 +559,15 @@ class TomographyContext(Context):
 
         res = []
         if self._last_transferred_file:
-            last_tilt_series = (
-                f"{extract_tilt_tag(self._last_transferred_file)}_{extract_tilt_series(self._last_transferred_file)}"
-                if extract_tilt_tag(self._last_transferred_file)
-                else extract_tilt_series(self._last_transferred_file)
-            )
+            if extract_tilt_tag(self._last_transferred_file) and extract_tilt_series(
+                self._last_transferred_file
+            ):
+                last_tilt_series = f"{extract_tilt_tag(self._last_transferred_file)}_{extract_tilt_series(self._last_transferred_file)}"
+            elif extract_tilt_tag(self._last_transferred_file):
+                last_tilt_series = f"{extract_tilt_tag(self._last_transferred_file)}"
+            else:
+                last_tilt_series = extract_tilt_series(self._last_transferred_file)
+
             last_tilt_angle = extract_tilt_angle(self._last_transferred_file)
             self._last_transferred_file = file_path
             if (

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -548,12 +548,7 @@ class TomographyContext(Context):
 
         res = []
         if self._last_transferred_file:
-            if extract_tilt_tag(self._last_transferred_file) and extract_tilt_series(
-                self._last_transferred_file
-            ):
-                last_tilt_series = _construct_tilt_series_name(
-                    self._last_transferred_file
-                )
+            last_tilt_series = _construct_tilt_series_name(self._last_transferred_file)
 
             last_tilt_angle = extract_tilt_angle(self._last_transferred_file)
             self._last_transferred_file = file_path

--- a/tests/client/test_context.py
+++ b/tests/client/test_context.py
@@ -17,6 +17,8 @@ def test_tomography_context_initialisation_for_tomo(tmp_path):
 @patch("requests.get")
 @patch("requests.post")
 def test_tomography_context_add_tomo_tilt(mock_post, mock_get, tmp_path):
+    mock_post().status_code = 200
+
     env = MurfeyInstanceEnvironment(
         url=urlparse("http://localhost:8000"),
         client_id=0,
@@ -24,23 +26,24 @@ def test_tomography_context_add_tomo_tilt(mock_post, mock_get, tmp_path):
         default_destinations={tmp_path: str(tmp_path)},
     )
     context = TomographyContext("tomo", tmp_path)
-    (tmp_path / "Position_1_[30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_1_[30.0]_fractions.tiff",
+        tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
         environment=env,
     )
     assert context._tilt_series == {
-        "Position_1": [tmp_path / "Position_1_[30.0]_fractions.tiff"]
+        "Position_1": [tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"]
     }
     assert (
-        context._last_transferred_file == tmp_path / "Position_1_[30.0]_fractions.tiff"
+        context._last_transferred_file
+        == tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"
     )
-    (tmp_path / "Position_1_[-30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_1_[-30.0]_fractions.tiff",
+        tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
@@ -61,9 +64,9 @@ def test_tomography_context_add_tomo_tilt(mock_post, mock_get, tmp_path):
     assert context._completed_tilt_series == ["Position_1"]
 
     # Start Position_2, this is not complete
-    (tmp_path / "Position_2_[30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_2_002_[30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_2_[30.0]_fractions.tiff",
+        tmp_path / "Position_2_002_[30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
@@ -76,6 +79,8 @@ def test_tomography_context_add_tomo_tilt(mock_post, mock_get, tmp_path):
 @patch("requests.get")
 @patch("requests.post")
 def test_tomography_context_add_tomo_tilt_out_of_order(mock_post, mock_get, tmp_path):
+    mock_post().status_code = 200
+
     env = MurfeyInstanceEnvironment(
         url=urlparse("http://localhost:8000"),
         client_id=0,
@@ -83,42 +88,33 @@ def test_tomography_context_add_tomo_tilt_out_of_order(mock_post, mock_get, tmp_
         default_destinations={tmp_path: str(tmp_path)},
     )
     context = TomographyContext("tomo", tmp_path)
-    (tmp_path / "Position_1_[30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_1_[30.0]_fractions.tiff",
+        tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
         environment=env,
     )
     assert context._tilt_series == {
-        "Position_1": [tmp_path / "Position_1_[30.0]_fractions.tiff"]
+        "Position_1": [tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"]
     }
     assert (
-        context._last_transferred_file == tmp_path / "Position_1_[30.0]_fractions.tiff"
+        context._last_transferred_file
+        == tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"
     )
-    (tmp_path / "Position_1_[-30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_1_[-30.0]_fractions.tiff",
+        tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
         environment=env,
     )
     assert not context._completed_tilt_series
-    (tmp_path / "Position_2_[-30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_2_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_2_[-30.0]_fractions.tiff",
-        role="detector",
-        required_position_files=[],
-        required_strings=["fractions"],
-        environment=env,
-    )
-    assert len(context._tilt_series.values()) == 2
-    assert not context._completed_tilt_series
-    (tmp_path / "Position_2_[30.0]_fractions.tiff").touch()
-    context.post_transfer(
-        tmp_path / "Position_2_[30.0]_fractions.tiff",
+        tmp_path / "Position_2_002_[-30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
@@ -126,10 +122,20 @@ def test_tomography_context_add_tomo_tilt_out_of_order(mock_post, mock_get, tmp_
     )
     assert len(context._tilt_series.values()) == 2
     assert not context._completed_tilt_series
-    (tmp_path / "Position_3_[30.0]_fractions.tiff").touch()
-    (tmp_path / "Position_3_[-30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_2_001_[30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_3_[-30.0]_fractions.tiff",
+        tmp_path / "Position_2_001_[30.0]_date_time_fractions.tiff",
+        role="detector",
+        required_position_files=[],
+        required_strings=["fractions"],
+        environment=env,
+    )
+    assert len(context._tilt_series.values()) == 2
+    assert not context._completed_tilt_series
+    (tmp_path / "Position_3_001_[30.0]_date_time_fractions.tiff").touch()
+    (tmp_path / "Position_3_002_[-30.0]_date_time_fractions.tiff").touch()
+    context.post_transfer(
+        tmp_path / "Position_3_002_[-30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
@@ -166,6 +172,8 @@ def test_tomography_context_add_tomo_tilt_out_of_order(mock_post, mock_get, tmp_
 @patch("requests.get")
 @patch("requests.post")
 def test_tomography_context_add_tomo_tilt_delayed_tilt(mock_post, mock_get, tmp_path):
+    mock_post().status_code = 200
+
     env = MurfeyInstanceEnvironment(
         url=urlparse("http://localhost:8000"),
         client_id=0,
@@ -173,23 +181,24 @@ def test_tomography_context_add_tomo_tilt_delayed_tilt(mock_post, mock_get, tmp_
         default_destinations={tmp_path: str(tmp_path)},
     )
     context = TomographyContext("tomo", tmp_path)
-    (tmp_path / "Position_1_[30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_1_[30.0]_fractions.tiff",
+        tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
         environment=env,
     )
     assert context._tilt_series == {
-        "Position_1": [tmp_path / "Position_1_[30.0]_fractions.tiff"]
+        "Position_1": [tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"]
     }
     assert (
-        context._last_transferred_file == tmp_path / "Position_1_[30.0]_fractions.tiff"
+        context._last_transferred_file
+        == tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"
     )
-    (tmp_path / "Position_1_[-30.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / "Position_1_[-30.0]_fractions.tiff",
+        tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
@@ -210,9 +219,9 @@ def test_tomography_context_add_tomo_tilt_delayed_tilt(mock_post, mock_get, tmp_
     assert not context._completed_tilt_series
 
     # Now add the tilt which completes the series
-    (tmp_path / "Position_1_[60.0]_fractions.tiff").touch()
+    (tmp_path / "Position_1_003_[60.0]_data_time_fractions.tiff").touch()
     new_series = context.post_transfer(
-        tmp_path / "Position_1_[60.0]_fractions.tiff",
+        tmp_path / "Position_1_003_[60.0]_data_time_fractions.tiff",
         role="detector",
         required_position_files=[],
         required_strings=["fractions"],
@@ -233,6 +242,8 @@ def test_tomography_context_initialisation_for_serialem(tmp_path):
 def test_setting_tilt_series_size_and_completion_from_mdoc_parsing(
     mock_post, mock_get, tmp_path
 ):
+    mock_post.post().status_code = 200
+
     env = MurfeyInstanceEnvironment(
         url=urlparse("http://localhost:8000"),
         client_id=0,
@@ -251,21 +262,21 @@ def test_setting_tilt_series_size_and_completion_from_mdoc_parsing(
     assert context._tilt_series_sizes == {"test_1": 11}
     (tmp_path / "test_1.mdoc").touch()
     tilt = -50
-    (tmp_path / f"test_1_[{tilt:.1f}]_fractions.tiff").touch()
+    (tmp_path / f"test_1_001_[{tilt:.1f}]_data_time_fractions.tiff").touch()
     context.post_transfer(
-        tmp_path / f"test_1_[{tilt:.1f}]_fractions.tiff",
+        tmp_path / f"test_1_001_[{tilt:.1f}]_data_time_fractions.tiff",
         role="detector",
         environment=env,
         required_strings=["fractions"],
     )
     assert context._tilt_series == {
-        "test_1": [tmp_path / f"test_1_[{tilt:.1f}]_fractions.tiff"]
+        "test_1": [tmp_path / f"test_1_001_[{tilt:.1f}]_data_time_fractions.tiff"]
     }
-    for t in range(-40, 60, 10):
+    for i, t in enumerate(range(-40, 60, 10)):
         assert not context._completed_tilt_series
-        (tmp_path / f"test_1_[{t:.1f}]_fractions.tiff").touch()
+        (tmp_path / f"test_1_{i:03}_[{t:.1f}]_data_time_fractions.tiff").touch()
         context.post_transfer(
-            tmp_path / f"test_1_[{t:.1f}]_fractions.tiff",
+            tmp_path / f"test_1_{i:03}_[{t:.1f}]_data_time_fractions.tiff",
             role="detector",
             environment=env,
             required_strings=["fractions"],


### PR DESCRIPTION
Currently we return "0" if no tilt series number can be found. This then leads to tilt series names of the form "name_0".

It would be better to return no tilt series number then put in logic to handle that case.