### PR TITLE
More CLEM fixes

### DIFF
--- a/src/murfey/util/clem/lif.py
+++ b/src/murfey/util/clem/lif.py
@@ -71,7 +71,8 @@ def process_lif_file(
     img_xml_dir = img_dir / "metadata"
     for folder in (img_dir, img_xml_dir):
         if not folder.exists():
-            folder.mkdir(parents=True)
+            # Potential race condition when generating folders from multiple pools
+            folder.mkdir(parents=True, exist_ok=True)
             logger.info(f"Created {folder}")
         else:
             logger.info(f"{folder} already exists")

--- a/src/murfey/util/clem/tiff.py
+++ b/src/murfey/util/clem/tiff.py
@@ -95,6 +95,7 @@ def process_tiff_files(
         bit_depth = int(channels[c].attrib["Resolution"])
 
         # Find TIFFs from relevant channel and series
+        # Replace " " with "_" when comparing file name against series name as found in metadata
         tiff_sublist = [
             f
             for f in tiff_list

--- a/src/murfey/util/clem/tiff.py
+++ b/src/murfey/util/clem/tiff.py
@@ -99,7 +99,7 @@ def process_tiff_files(
             f
             for f in tiff_list
             if (f"C{str(c).zfill(2)}" in f.stem or f"C{str(c).zfill(3)}" in f.stem)
-            and (img_name == f.stem.split("--")[0])
+            and (img_name.replace(" ", "_") == f.stem.split("--")[0].replace(" ", "_"))
         ]
         tiff_sublist.sort(
             key=lambda f: (int(f.stem.split("--")[1].replace("Z", "")),)

--- a/src/murfey/workflows/lif_to_tiff.py
+++ b/src/murfey/workflows/lif_to_tiff.py
@@ -36,9 +36,8 @@ def zocalo_cluster_request(
             {
                 "recipes": ["lif-to-tiff"],
                 "parameters": {
-                    # Represent file paths canonically
-                    "session_dir": repr(str(session_dir)),
-                    "lif_path": repr(str(file)),
+                    "session_dir": str(session_dir),
+                    "lif_path": str(file),
                     "root_dir": root_folder,
                 },
             },


### PR DESCRIPTION
Further work on issues raised in #304.
- [x] Replace spaces with underscores whenever comparing the file name to its name as stored in the metadata
- [x] Corrects LIF-to-TIFF zocalo cluster submission