### PR TITLE
When re-establishing RabbitMQ connection create new transport object

### DIFF
--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -90,13 +90,7 @@ class TransportManager:
     def send(self, queue: str, message: dict, new_connection: bool = False):
         if self.transport:
             if not self.transport.is_connected():
-                try:
-                    self.transport.disconnect()
-                except AttributeError:
-                    # If there is not _pika_thread to join on the transport
-                    # then don't need to worry about dicsonnecting
-                    pass
-                self.transport.connect()
+                self.reconnect()
                 if self._connection_callback:
                     self._connection_callback()
             if new_connection:

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -63,7 +63,10 @@ class TransportManager:
         try:
             self.transport.disconnect()
         except Exception:
-            pass
+            log.warning(
+                "Disconnection of olf old transport failed when reconnecting",
+                exc_info=True,
+            )
         self.transport = workflows.transport.lookup(self._transport_type)()
         self.transport.connect()
 

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -59,6 +59,14 @@ class TransportManager:
         self.ispyb = ispyb.open()
         self._connection_callback: Callable | None = None
 
+    def reconnect(self):
+        try:
+            self.transport.disconnect()
+        except Exception:
+            pass
+        self.transport = workflows.transport.lookup(self._transport_type)()
+        self.transport.connect()
+
     def do_insert_data_collection_group(
         self,
         record: DataCollectionGroup,

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -64,7 +64,7 @@ class TransportManager:
             self.transport.disconnect()
         except Exception:
             log.warning(
-                "Disconnection of olf old transport failed when reconnecting",
+                "Disconnection of old transport failed when reconnecting",
                 exc_info=True,
             )
         self.transport = workflows.transport.lookup(self._transport_type)()


### PR DESCRIPTION
On sends from a `TransportManager` instance there is currently a check on the connection. This doesn't work as it tries to start and existing thread. A new transport object should be created and connected instead. Resolves #324 