### PR TITLE
Record tomography preprocessing in prometheus

### DIFF
--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2438,9 +2438,7 @@ def feedback_callback(header: dict, message: dict) -> None:
                         f"No transport object found. Zocalo message would be {zocalo_message}"
                     )
 
-            prom.preprocessed_movies.labels(
-                processing_job=_pj_id(message["program_id"], murfey_db)
-            ).inc()
+            prom.preprocessed_movies.labels(processing_job=collected_ids[2].id).inc()
             murfey_db.commit()
             murfey_db.close()
             if _transport_object:

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2438,6 +2438,9 @@ def feedback_callback(header: dict, message: dict) -> None:
                         f"No transport object found. Zocalo message would be {zocalo_message}"
                     )
 
+            prom.preprocessed_movies.labels(
+                processing_job=_pj_id(message["program_id"], murfey_db)
+            ).inc()
             murfey_db.commit()
             murfey_db.close()
             if _transport_object:


### PR DESCRIPTION
We aren't currently displaying the processing of tomography tilts on grafana. But we do create the prometheus metric objects needed for that, and they only require a program id.

As the program id is sent in the `motion_corrected` feedback message, I think we can just add an increment to the metric and it will work.

Do you see any reason why this wouldn't work?