### PR TITLE
Create a new workflow to publish releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # Contains tasks to be repeated when testing for the different Python versions listed
-# in the "Run unit tests" stage in .github/workflows/test-and-publish.yml
+# in the "Run unit tests" stage in .github/workflows/test.yml
 name: Run tests
 
 on:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -1,9 +1,8 @@
-name: Make new tags and publish Python distribution to PyPI
+name: Publish version
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+
 permissions:
   contents: read
 
@@ -12,8 +11,8 @@ jobs:
     name: Get version
     runs-on: ubuntu-latest
     outputs:
-      doTag: ${{ steps.checkTag.outputs.newTag }}
-      newVersion:
+      doTag: ${{ steps.checkTag.outputs.doTag }}
+      newVersion: ${{ steps.checkTag.outputs.newVersion }}
     steps:
       - uses: actions/checkout@v4
       - name: Check current tag
@@ -56,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - get-current-version
-    if: ${{ needs.get-current-version.outputs.newTag == 'true' }}
+    if: ${{ needs.get-current-version.outputs.doTag == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
@@ -84,7 +83,7 @@ jobs:
       - get-current-version
       - build
       - make-tag
-    if: ${{ needs.get-current-version.outputs.newTag == 'true' }}
+    if: ${{ needs.get-current-version.outputs.doTag == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -108,7 +107,7 @@ jobs:
     needs:
       - get-current-version
       - publish-to-pypi
-    if: ${{ needs.get-current-version.outputs.newTag == 'true' }}
+    if: ${{ needs.get-current-version.outputs.doTag == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -1,7 +1,9 @@
 name: Publish version
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/publish-version.yml
+++ b/.github/workflows/publish-version.yml
@@ -1,38 +1,62 @@
-name: Run tests and publish Python distribution to PyPI
+name: Make new tags and publish Python distribution to PyPI
 
-on: [push, pull_request]
-
-env:
-  DATABASE_SCHEMA: 4.2.1 # released 2024-08-19
-  # Installs from GitHub
-  # Versions: https://github.com/DiamondLightSource/ispyb-database/tags
-  # Previous version(s):
-  # 4.1.0
-
+on:
+  push:
+    branches:
+      - main
 permissions:
   contents: read
 
 jobs:
-  static:
-    name: Static Analysis
+  get-current-version:
+    name: Get version
     runs-on: ubuntu-latest
+    outputs:
+      doTag: ${{ steps.checkTag.outputs.newTag }}
+      newVersion:
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - name: Syntax validation
+      - name: Check current tag
+        id: checkTag
         run: |
-          python .github/workflows/scripts/syntax-validation.py
-      - name: Flake8 validation
+          pip install --disable-pip-version-check -e "."[cicd,client,server,developer]
+          VERSION=$(python -c "import murfey; print(murfey.__version__)")
+          echo "newVersion=v$VERSION" >> $GITHUB_OUTPUT
+
+          if [ $(git tag -l v$VERSION) ]; then
+            echo "Version is up to date at $VERSION"
+            echo "doTag=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version needs to be updated to $VERSION"
+            echo "doTag=true" >> $GITHUB_OUTPUT
+          fi
+
+  make-tag:
+    name: Create a new tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs:
+      - get-current-version
+    if: ${{ needs.get-current-version.outputs.doTag == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Push the new tag
         run: |
-          pip install flake8
-          python .github/workflows/scripts/flake8-validation.py
+          git config --global user.name "DiamondLightSource-build-server"
+          git config --global user.email "DiamondLightSource-build-server@users.noreply.github.com"
+          git config credential.helper "store --file=.git/credentials"
+          echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
+
+          git tag ${{ needs.get-current-version.outputs.newVersion }}
+          git push origin ${{ needs.get-current-version.outputs.newVersion }}
 
   build:
     name: Build package
     runs-on: ubuntu-latest
+    needs:
+      - get-current-version
+    if: ${{ needs.get-current-version.outputs.newTag == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
@@ -47,36 +71,20 @@ jobs:
           --user
       - name: Build python package
         run: python3 -m build
-      - name: Download ISPyB DB schema v${{ env.DATABASE_SCHEMA }} for tests
-        run: |
-          mkdir database
-          wget -t 3 --waitretry=20 https://github.com/DiamondLightSource/ispyb-database/releases/download/v${{ env.DATABASE_SCHEMA }}/ispyb-database-${{ env.DATABASE_SCHEMA }}.tar.gz -O database/ispyb-database.tar.gz
       - name: Store built package artifact
         uses: actions/upload-artifact@v4
         with:
           name: package-distributions
           path: dist/
-      - name: Store database artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: database
-          path: database/
-
-  tests:
-    name: Call ci unit tests workflow
-    uses: ./.github/workflows/ci.yml
-    needs:
-      - build
-      - static
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   publish-to-pypi:
     name: >-
       Publish Python distribution to PyPI
-    if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
     needs:
-      - tests
+      - get-current-version
+      - build
+      - make-tag
+    if: ${{ needs.get-current-version.outputs.newTag == 'true' }}
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -98,7 +106,9 @@ jobs:
       Sign the Python distribution with Sigstore
       and upload them to GitHub Release
     needs:
+      - get-current-version
       - publish-to-pypi
+    if: ${{ needs.get-current-version.outputs.newTag == 'true' }}
     runs-on: ubuntu-latest
 
     permissions:
@@ -122,7 +132,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: >-
           gh release create
-          '${{ github.ref_name }}'
+          '${{ needs.get-current-version.outputs.newVersion }}'
           --repo '${{ github.repository }}'
           --notes ""
       - name: Upload artifact signatures to GitHub Release
@@ -133,5 +143,5 @@ jobs:
         # sigstore-produced signatures and certificates.
         run: >-
           gh release upload
-          '${{ github.ref_name }}' dist/**
+          '${{ needs.get-current-version.outputs.newVersion }}' dist/**
           --repo '${{ github.repository }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Build and test
 
 on: [push, pull_request]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,74 @@
+name: Run tests
+
+on: [push, pull_request]
+
+env:
+  DATABASE_SCHEMA: 4.2.1 # released 2024-08-19
+  # Installs from GitHub
+  # Versions: https://github.com/DiamondLightSource/ispyb-database/tags
+  # Previous version(s):
+  # 4.1.0
+
+permissions:
+  contents: read
+
+jobs:
+  static:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Syntax validation
+        run: |
+          python .github/workflows/scripts/syntax-validation.py
+      - name: Flake8 validation
+        run: |
+          pip install flake8
+          python .github/workflows/scripts/flake8-validation.py
+
+  build:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install pypa/build
+        run: >-
+          python3 -m
+          pip install
+          build
+          --user
+      - name: Build python package
+        run: python3 -m build
+
+  get-database:
+    name: Build package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download ISPyB DB schema v${{ env.DATABASE_SCHEMA }} for tests
+        run: |
+          mkdir database
+          wget -t 3 --waitretry=20 https://github.com/DiamondLightSource/ispyb-database/releases/download/v${{ env.DATABASE_SCHEMA }}/ispyb-database-${{ env.DATABASE_SCHEMA }}.tar.gz -O database/ispyb-database.tar.gz
+      - name: Store database artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: database
+          path: database/
+
+  tests:
+    name: Call ci unit tests workflow
+    uses: ./.github/workflows/ci.yml
+    needs:
+      - build
+      - get-database
+      - static
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -38,8 +38,19 @@ jobs:
           git config --global user.email "DiamondLightSource-build-server@users.noreply.github.com"
           git config credential.helper "store --file=.git/credentials"
           echo "https://${GITHUB_TOKEN}:@github.com" > .git/credentials
+
           bump2version ${{ inputs.bumpLevel }}
-          git push origin main
-          pip install --disable-pip-version-check -e "."[cicd,client,server,developer]
-          VERSION=$(python -c "import murfey; print(murfey.__version__)")
-          git push origin v$VERSION
+
+          echo "##[section]Creating commit on branch 'version-bump'"
+          git checkout -b version-bump
+          bump2version ${{ inputs.bumpLevel }}
+
+          echo "##[section]Creating pull request"
+          git push -f --set-upstream origin version-bump
+          gh pr create -B main -H version-bump -t "Version update (${{ inputs.bumpLevel }})" -b "
+          This is an automated pull request to update the version.
+
+          After merging this, you should run the \`Publish version\` action
+          to tag this release and publish to pypi.
+          "
+          echo

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -50,7 +50,6 @@ jobs:
           gh pr create -B main -H version-bump -t "Version update (${{ inputs.bumpLevel }})" -b "
           This is an automated pull request to update the version.
 
-          After merging this, you should run the \`Publish version\` action
-          to tag this release and publish to pypi.
+          After merging this, the \`Publish version\` action will tag this release and publish to pypi.
           "
           echo


### PR DESCRIPTION
Automatic version bumping and releases weren't working. This PR moves the pypi release parts to a new workflow that pushes tags and publishes releases.

The version bump workflow has also changed, so that it now creates a PR. When that is merged, the publishing workflow should trigger.