### PR TITLE
Fixes for picking up external post transfer hooks

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -86,6 +86,10 @@ class Analyser(Observer):
         """
         Identifies the file extension and stores that information in the class.
         """
+        if "atlas" in file_path.parts:
+            self._extension = file_path.suffix
+            return True
+
         if (
             required_substrings := self._murfey_config.get(
                 "data_required_substrings", {}
@@ -121,6 +125,10 @@ class Analyser(Observer):
         stages of processing. Actions to take for individual files will be determined
         in the Context classes themselves.
         """
+        if "atlas" in file_path.parts:
+            self._role = "detector"
+            self._context = SPAMetadataContext("epu", self._basepath)
+            return True
 
         # CLEM workflow checks
         # Look for LIF and XLIF files
@@ -376,7 +384,10 @@ class Analyser(Observer):
                             )
                         except Exception as e:
                             logger.error(f"Exception encountered: {e}")
-                        if self._role == "detector":
+                        if (
+                            self._role == "detector"
+                            and "atlas" not in transferred_file.parts
+                        ):
                             if not dc_metadata:
                                 try:
                                     dc_metadata = self._context.gather_metadata(

--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -318,7 +318,10 @@ class Analyser(Observer):
                             )
                         except Exception as e:
                             logger.error(f"Exception encountered: {e}")
-                        if self._role == "detector":
+                        if (
+                            self._role == "detector"
+                            and "atlas" not in transferred_file.parts
+                        ):
                             if not dc_metadata:
                                 try:
                                     dc_metadata = self._context.gather_metadata(

--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -673,6 +673,12 @@ class SPAModularContext(_SPAContext):
         environment: MurfeyInstanceEnvironment | None = None,
         **kwargs,
     ) -> bool:
+        super().post_transfer(
+            transferred_file=transferred_file,
+            role=role,
+            environment=environment,
+            **kwargs,
+        )
         data_suffixes = (".mrc", ".tiff", ".tif", ".eer")
         if role == "detector" and "gain" not in transferred_file.name:
             if transferred_file.suffix in data_suffixes:

--- a/src/murfey/client/contexts/spa_metadata.py
+++ b/src/murfey/client/contexts/spa_metadata.py
@@ -35,7 +35,7 @@ def _atlas_destination(
 
 class SPAMetadataContext(Context):
     def __init__(self, acquisition_software: str, basepath: Path):
-        super().__init__("SPA metadata", acquisition_software)
+        super().__init__("SPA_metadata", acquisition_software)
         self._basepath = basepath
 
     def post_transfer(
@@ -45,6 +45,13 @@ class SPAMetadataContext(Context):
         environment: Optional[MurfeyInstanceEnvironment] = None,
         **kwargs,
     ):
+        super().post_transfer(
+            transferred_file=transferred_file,
+            role=role,
+            environment=environment,
+            **kwargs,
+        )
+
         if transferred_file.name == "EpuSession.dm" and environment:
             logger.info("EPU session metadata found")
             with open(transferred_file, "r") as epu_xml:

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -781,6 +781,13 @@ class TomographyContext(Context):
         environment: MurfeyInstanceEnvironment | None = None,
         **kwargs,
     ) -> List[str]:
+        super().post_transfer(
+            transferred_file=transferred_file,
+            role=role,
+            environment=environment,
+            **kwargs,
+        )
+
         data_suffixes = (".mrc", ".tiff", ".tif", ".eer")
         completed_tilts = []
         if role == "detector" and "gain" not in transferred_file.name:


### PR DESCRIPTION
Allows post transfer hooks for the atlas directory through analyser additions.

Calls the superclass hooks in all contexts.