### PR TITLE
Remove the need for an ISPyB instance

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -22,7 +22,7 @@ from murfey.client.contexts.tomo import TomographyContext
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
 from murfey.client.rsync import RSyncerUpdate, TransferResult
 from murfey.client.tui.forms import FormDependency
-from murfey.util import Observer, get_machine_config
+from murfey.util import Observer, get_machine_config_client
 from murfey.util.models import PreprocessingParametersTomo, ProcessingParametersSPA
 
 logger = logging.getLogger("murfey.client.analyser")
@@ -73,7 +73,7 @@ class Analyser(Observer):
         self._stopping = False
         self._halt_thread = False
         self._murfey_config = (
-            get_machine_config(
+            get_machine_config_client(
                 str(environment.url.geturl()),
                 instrument_name=environment.instrument_name,
                 demo=environment.demo,
@@ -145,7 +145,7 @@ class Analyser(Observer):
             and self._environment
         ):
             created_directories = set(
-                get_machine_config(
+                get_machine_config_client(
                     str(self._environment.url.geturl()),
                     instrument_name=self._environment.instrument_name,
                     demo=self._environment.demo,
@@ -165,7 +165,7 @@ class Analyser(Observer):
                     logger.info("Acquisition software: EPU")
                     if self._environment:
                         try:
-                            cfg = get_machine_config(
+                            cfg = get_machine_config_client(
                                 str(self._environment.url.geturl()),
                                 instrument_name=self._environment.instrument_name,
                                 demo=self._environment.demo,

--- a/src/murfey/client/contexts/clem.py
+++ b/src/murfey/client/contexts/clem.py
@@ -14,7 +14,7 @@ from defusedxml.ElementTree import parse
 
 from murfey.client.context import Context
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
-from murfey.util import capture_post, get_machine_config
+from murfey.util import capture_post, get_machine_config_client
 
 # Create logger object
 logger = logging.getLogger("murfey.client.contexts.clem")
@@ -26,7 +26,7 @@ def _file_transferred_to(
     """
     Returns the Path of the transferred file on the DLS file system.
     """
-    machine_config = get_machine_config(
+    machine_config = get_machine_config_client(
         str(environment.url.geturl()),
         instrument_name=environment.instrument_name,
         demo=environment.demo,

--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -19,7 +19,7 @@ from murfey.util import (
     authorised_requests,
     capture_get,
     capture_post,
-    get_machine_config,
+    get_machine_config_client,
 )
 
 logger = logging.getLogger("murfey.client.contexts.spa")
@@ -105,7 +105,7 @@ def _get_grid_square_atlas_positions(
 def _file_transferred_to(
     environment: MurfeyInstanceEnvironment, source: Path, file_path: Path
 ):
-    machine_config = get_machine_config(
+    machine_config = get_machine_config_client(
         str(environment.url.geturl()),
         instrument_name=environment.instrument_name,
         demo=environment.demo,
@@ -684,7 +684,7 @@ class SPAModularContext(_SPAContext):
             if transferred_file.suffix in data_suffixes:
                 if self._acquisition_software == "epu":
                     if environment:
-                        machine_config = get_machine_config(
+                        machine_config = get_machine_config_client(
                             str(environment.url.geturl()),
                             instrument_name=environment.instrument_name,
                             demo=environment.demo,
@@ -872,7 +872,7 @@ class SPAContext(_SPAContext):
         parameters = parameters or {}
         environment.id_tag_registry["processing_job"].append(tag)
         proc_url = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.murfey_session}/register_processing_job"
-        machine_config = get_machine_config(
+        machine_config = get_machine_config_client(
             str(environment.url.geturl()),
             instrument_name=environment.instrument_name,
             demo=environment.demo,

--- a/src/murfey/client/contexts/spa_metadata.py
+++ b/src/murfey/client/contexts/spa_metadata.py
@@ -8,7 +8,7 @@ import xmltodict
 from murfey.client.context import Context
 from murfey.client.contexts.spa import _get_grid_square_atlas_positions, _get_source
 from murfey.client.instance_environment import MurfeyInstanceEnvironment, SampleInfo
-from murfey.util import authorised_requests, capture_post, get_machine_config
+from murfey.util import authorised_requests, capture_post, get_machine_config_client
 
 logger = logging.getLogger("murfey.client.contexts.spa_metadata")
 
@@ -18,7 +18,7 @@ requests.get, requests.post, requests.put, requests.delete = authorised_requests
 def _atlas_destination(
     environment: MurfeyInstanceEnvironment, source: Path, file_path: Path
 ) -> Path:
-    machine_config = get_machine_config(
+    machine_config = get_machine_config_client(
         str(environment.url.geturl()),
         instrument_name=environment.instrument_name,
         demo=environment.demo,

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -19,7 +19,7 @@ from murfey.client.instance_environment import (
     MurfeyInstanceEnvironment,
     global_env_lock,
 )
-from murfey.util import authorised_requests, capture_post, get_machine_config
+from murfey.util import authorised_requests, capture_post, get_machine_config_client
 from murfey.util.mdoc import get_block, get_global_data, get_num_blocks
 
 logger = logging.getLogger("murfey.client.contexts.tomo")
@@ -341,7 +341,7 @@ class TomographyContext(Context):
     def _file_transferred_to(
         self, environment: MurfeyInstanceEnvironment, source: Path, file_path: Path
     ):
-        machine_config = get_machine_config(
+        machine_config = get_machine_config_client(
             str(environment.url.geturl()),
             instrument_name=environment.instrument_name,
             demo=environment.demo,
@@ -794,7 +794,7 @@ class TomographyContext(Context):
             if transferred_file.suffix in data_suffixes:
                 if self._acquisition_software == "tomo":
                     if environment:
-                        machine_config = get_machine_config(
+                        machine_config = get_machine_config_client(
                             str(environment.url.geturl()),
                             instrument_name=environment.instrument_name,
                             demo=environment.demo,

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -173,6 +173,7 @@ class MultigridController:
         remove_files: bool = False,
         tag: str = "",
         limited: bool = False,
+        transfer: bool = True,
     ):
         log.info(f"starting rsyncer: {source}")
         if self._environment:
@@ -189,47 +190,48 @@ class MultigridController:
                     log.warning(
                         f"Gain reference file {self._environment.gain_ref} was not successfully transferred to {visit_path}/processing"
                     )
-        self.rsync_processes[source] = RSyncer(
-            source,
-            basepath_remote=Path(destination),
-            server_url=self._environment.url,
-            stop_callback=self._rsyncer_stopped,
-            do_transfer=self.do_transfer,
-            remove_files=remove_files,
-        )
+        if transfer:
+            self.rsync_processes[source] = RSyncer(
+                source,
+                basepath_remote=Path(destination),
+                server_url=self._environment.url,
+                stop_callback=self._rsyncer_stopped,
+                do_transfer=self.do_transfer,
+                remove_files=remove_files,
+            )
 
-        def rsync_result(update: RSyncerUpdate):
-            if not update.base_path:
-                raise ValueError("No base path from rsyncer update")
-            if not self.rsync_processes.get(update.base_path):
-                raise ValueError("TUI rsync process does not exist")
-            if update.outcome is TransferResult.SUCCESS:
-                # log.info(
-                #     f"File {str(update.file_path)!r} successfully transferred ({update.file_size} bytes)"
-                # )
-                pass
-            else:
-                log.warning(f"Failed to transfer file {str(update.file_path)!r}")
-                self.rsync_processes[update.base_path].enqueue(update.file_path)
+            def rsync_result(update: RSyncerUpdate):
+                if not update.base_path:
+                    raise ValueError("No base path from rsyncer update")
+                if not self.rsync_processes.get(update.base_path):
+                    raise ValueError("TUI rsync process does not exist")
+                if update.outcome is TransferResult.SUCCESS:
+                    # log.info(
+                    #     f"File {str(update.file_path)!r} successfully transferred ({update.file_size} bytes)"
+                    # )
+                    pass
+                else:
+                    log.warning(f"Failed to transfer file {str(update.file_path)!r}")
+                    self.rsync_processes[update.base_path].enqueue(update.file_path)
 
-        self.rsync_processes[source].subscribe(rsync_result)
-        self.rsync_processes[source].subscribe(
-            partial(
-                self._increment_transferred_files,
-                destination=destination,
-                source=str(source),
-            ),
-            secondary=True,
-        )
-        url = f"{str(self._environment.url.geturl())}/sessions/{str(self._environment.murfey_session)}/rsyncer"
-        rsyncer_data = {
-            "source": str(source),
-            "destination": destination,
-            "session_id": self.session_id,
-            "transferring": self.do_transfer or self._environment.demo,
-            "tag": tag,
-        }
-        requests.post(url, json=rsyncer_data)
+            self.rsync_processes[source].subscribe(rsync_result)
+            self.rsync_processes[source].subscribe(
+                partial(
+                    self._increment_transferred_files,
+                    destination=destination,
+                    source=str(source),
+                ),
+                secondary=True,
+            )
+            url = f"{str(self._environment.url.geturl())}/sessions/{str(self._environment.murfey_session)}/rsyncer"
+            rsyncer_data = {
+                "source": str(source),
+                "destination": destination,
+                "session_id": self.session_id,
+                "transferring": self.do_transfer or self._environment.demo,
+                "tag": tag,
+            }
+            requests.post(url, json=rsyncer_data)
         self._environment.watchers[source] = DirWatcher(source, settling_time=30)
 
         if not self.analysers.get(source) and analyse:
@@ -254,15 +256,36 @@ class MultigridController:
             else:
                 self.analysers[source].subscribe(self._data_collection_form)
             self.analysers[source].start()
-            self.rsync_processes[source].subscribe(self.analysers[source].enqueue)
+            if transfer:
+                self.rsync_processes[source].subscribe(self.analysers[source].enqueue)
 
-        self.rsync_processes[source].start()
+        if transfer:
+            self.rsync_processes[source].start()
 
         if self._environment:
             if self._environment.watchers.get(source):
-                self._environment.watchers[source].subscribe(
-                    self.rsync_processes[source].enqueue
-                )
+                if transfer:
+                    self._environment.watchers[source].subscribe(
+                        self.rsync_processes[source].enqueue
+                    )
+                else:
+                    # the watcher and rsyncer don't notify with the same object so conversion required here
+                    def _rsync_update_converter(p: Path) -> None:
+                        self.analysers[source].enqueue(
+                            RSyncerUpdate(
+                                file_path=p,
+                                file_size=0,
+                                outcome=TransferResult.SUCCESS,
+                                transfer_total=0,
+                                queue_size=0,
+                                base_path=source,
+                            )
+                        )
+                        return None
+
+                    self._environment.watchers[source].subscribe(
+                        _rsync_update_converter
+                    )
                 self._environment.watchers[source].subscribe(
                     partial(
                         self._increment_file_count,

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -133,6 +133,7 @@ class MultigridController:
             remove_files=remove_files,
             tag=tag,
             limited=limited,
+            transfer=machine_data.get("data_transfer_enabled", True),
         )
         self.ws.send(json.dumps({"message": "refresh"}))
 

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -25,6 +25,7 @@ from murfey.client.tui.screens import (
     MainScreen,
     ProcessingForm,
     SessionSelection,
+    VisitCreation,
     VisitSelection,
     WaitingScreen,
     determine_default_destination,
@@ -682,8 +683,12 @@ class MurfeyTUI(App):
         exisiting_sessions = requests.get(
             f"{self._environment.url.geturl()}/sessions"
         ).json()
-        self.install_screen(VisitSelection(self.visits), "visit-select-screen")
-        self.push_screen("visit-select-screen")
+        if self.visits:
+            self.install_screen(VisitSelection(self.visits), "visit-select-screen")
+            self.push_screen("visit-select-screen")
+        else:
+            self.install_screen(VisitCreation(), "visit-creation-screen")
+            self.push_screen("visit-creation-screen")
         if exisiting_sessions:
             self.install_screen(
                 SessionSelection(

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -34,7 +34,7 @@ from murfey.client.watchdir import DirWatcher
 from murfey.client.watchdir_multigrid import MultigridDirWatcher
 from murfey.util import (
     capture_post,
-    get_machine_config,
+    get_machine_config_client,
     read_config,
     set_default_acquisition_output,
 )
@@ -104,7 +104,7 @@ class MurfeyTUI(App):
         self._force_mdoc_metadata = force_mdoc_metadata
         self._strict = strict
         self._skip_existing_processing = skip_existing_processing
-        self._machine_config = get_machine_config(
+        self._machine_config = get_machine_config_client(
             str(self._environment.url.geturl()),
             instrument_name=self._environment.instrument_name,
             demo=self._environment.demo,
@@ -128,7 +128,7 @@ class MurfeyTUI(App):
         self, source: Path, destination_overrides: Dict[Path, str] | None = None
     ):
         log.info(f"Launching multigrid watcher for source {source}")
-        machine_config = get_machine_config(
+        machine_config = get_machine_config_client(
             str(self._environment.url.geturl()),
             instrument_name=self._environment.instrument_name,
             demo=self._environment.demo,
@@ -688,7 +688,7 @@ class MurfeyTUI(App):
         self.log_book.write(message.renderable)
 
     async def reset(self):
-        machine_config = get_machine_config(
+        machine_config = get_machine_config_client(
             str(self._environment.url.geturl()),
             instrument_name=self._environment.instrument_name,
             demo=self._environment.demo,
@@ -743,7 +743,7 @@ class MurfeyTUI(App):
         exit()
 
     async def action_clear(self) -> None:
-        machine_config = get_machine_config(
+        machine_config = get_machine_config_client(
             str(self._environment.url.geturl()),
             instrument_name=self._environment.instrument_name,
             demo=self._environment.demo,

--- a/src/murfey/client/tui/controller.css
+++ b/src/murfey/client/tui/controller.css
@@ -46,6 +46,12 @@ SessionSelection {
   border: hidden;
 }
 
+VisitCreation {
+  layout: grid;
+  grid-size: 2;
+  border: hidden;
+}
+
 VisitSelection {
   layout: grid;
   grid-size: 4;
@@ -232,6 +238,22 @@ RadioSet {
 }
 
 .btn-visit:focus {
+  background: darkslateblue;
+}
+
+.btn-visit-create {
+  width: 100%;
+  height: 90fr;
+  column-span: 2;
+  background: teal;
+  border: solid black;
+}
+
+.btn-visit-create:hover {
+  background: purple;
+}
+
+.btn-visit-create:focus {
   background: darkslateblue;
 }
 
@@ -466,6 +488,16 @@ RadioSet {
 .input-destination {
   width: 100%;
   background: black;
+}
+
+.input-visit-name {
+  width: 100%;
+  height: 100%;
+  column-span: 2;
+  row-span: 1;
+  content-align: left middle;
+  text-style: bold;
+  background: blueviolet;
 }
 
 #log_book {

--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -761,6 +761,8 @@ class VisitSelection(SwitchSelection):
 
 
 class VisitCreation(Screen):
+    # This allows for the manual creation of a visit name when there is no LIMS system to provide it
+    # Shares a lot of code with VisitSelection, should be neatened up at some point
     visit_name: reactive[str] = reactive("")
 
     def __init__(self, *args, **kwargs):

--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -760,6 +760,70 @@ class VisitSelection(SwitchSelection):
             self.app.push_screen("upstream-downloads")
 
 
+class VisitCreation(Screen):
+    visit_name: reactive[str] = reactive("")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def compose(self):
+        yield Input(placeholder="Visit name", classes="input-visit-name")
+        yield Button("Create visit", classes="btn-visit-create")
+
+    def on_input_changed(self, event):
+        self.visit_name = event.value
+
+    def on_button_pressed(self, event: Button.Pressed):
+        text = str(self.visit_name)
+        self.app._visit = text
+        self.app._environment.visit = text
+        response = requests.post(
+            f"{self.app._environment.url.geturl()}/visits/{text}",
+            json={"id": self.app._environment.client_id},
+        )
+        log.info(f"Posted visit registration: {response.status_code}")
+        machine_data = requests.get(
+            f"{self.app._environment.url.geturl()}/machine"
+        ).json()
+
+        self.app.install_screen(
+            DirectorySelection(
+                [
+                    p[0]
+                    for p in machine_data.get("data_directories", {}).items()
+                    if p[1] == "detector" and Path(p[0]).exists()
+                ]
+            ),
+            "directory-select",
+        )
+        self.app.pop_screen()
+
+        if machine_data.get("gain_reference_directory"):
+            self.app.install_screen(
+                GainReference(
+                    determine_gain_ref(Path(machine_data["gain_reference_directory"])),
+                    True,
+                ),
+                "gain-ref-select",
+            )
+            self.app.push_screen("gain-ref-select")
+        else:
+            if self._switch_status:
+                self.app.push_screen("directory-select")
+            else:
+                self.app.install_screen(LaunchScreen(basepath=Path("./")), "launcher")
+                self.app.push_screen("launcher")
+
+        if machine_data.get("upstream_data_directories"):
+            upstream_downloads = requests.get(
+                f"{self.app._environment.url.geturl()}/sessions/{self.app._environment.murfey_session}/upstream_visits"
+            ).json()
+            self.app.install_screen(
+                UpstreamDownloads(upstream_downloads), "upstream-downloads"
+            )
+            self.app.push_screen("upstream-downloads")
+
+
 class UpstreamDownloads(Screen):
     def __init__(self, connected_visits: Dict[str, Path], *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -56,7 +56,7 @@ from murfey.client.instance_environment import (
 )
 from murfey.client.rsync import RSyncer
 from murfey.client.tui.forms import FormDependency
-from murfey.util import capture_post, get_machine_config, read_config
+from murfey.util import capture_post, get_machine_config_client, read_config
 from murfey.util.models import PreprocessingParametersTomo, ProcessingParametersSPA
 
 log = logging.getLogger("murfey.tui.screens")
@@ -262,7 +262,7 @@ class LaunchScreen(Screen):
         super().__init__(*args, **kwargs)
         self._selected_dir = basepath
         self._add_basepath = add_basepath
-        cfg = get_machine_config(
+        cfg = get_machine_config_client(
             str(self.app._environment.url.geturl()),
             instrument_name=self.app._environment.instrument_name,
             demo=self.app._environment.demo,
@@ -898,7 +898,7 @@ class DirectorySelection(SwitchSelection):
         visit_dir = Path(str(event.button.label)) / self.app._visit
         visit_dir.mkdir(exist_ok=True)
         self.app._set_default_acquisition_directories(visit_dir)
-        machine_config = get_machine_config(
+        machine_config = get_machine_config_client(
             str(self.app._environment.url.geturl()),
             instrument_name=self.app._environment.instrument_name,
             demo=self.app._environment.demo,
@@ -940,7 +940,7 @@ class DestinationSelect(Screen):
             )
             yield RadioButton("Tomography", value=self._context is TomographyContext)
         if self.app._multigrid:
-            machine_config = get_machine_config(
+            machine_config = get_machine_config_client(
                 str(self.app._environment.url.geturl()),
                 instrument_name=self.app._environment.instrument_name,
             )
@@ -1000,7 +1000,7 @@ class DestinationSelect(Screen):
                                 )
                             )
         else:
-            machine_config = get_machine_config(
+            machine_config = get_machine_config_client(
                 str(self.app._environment.url.geturl()),
                 instrument_name=self.app._environment.instrument_name,
             )
@@ -1031,7 +1031,7 @@ class DestinationSelect(Screen):
                     i = Input(value=val, id=k.name, classes="input-destination")
                 params_bulk.append(i)
                 self._inputs[i] = k.name
-            machine_config = get_machine_config(
+            machine_config = get_machine_config_client(
                 str(self.app._environment.url.geturl()),
                 instrument_name=self.app._environment.instrument_name,
                 demo=self.app._environment.demo,
@@ -1083,7 +1083,7 @@ class DestinationSelect(Screen):
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
         if event.index == 0:
-            cfg = get_machine_config(
+            cfg = get_machine_config_client(
                 str(self.app._environment.url.geturl()),
                 instrument_name=self.app._environment.instrument_name,
                 demo=self.app._environment.demo,

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -237,9 +237,9 @@ def get_possible_gain_references(
         headers={"Authorization": f"Bearer {tokens[session_id]}"},
     ).json()
     candidates = []
-    for gf in secure_path(Path(machine_config["gain_reference_directory"])).glob(
-        "**/*"
-    ):
+    for gf in secure_path(
+        Path(machine_config["gain_reference_directory"]), keep_spaces=True
+    ).glob("**/*"):
         if gf.is_file():
             candidates.append(
                 File(

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2745,11 +2745,9 @@ def feedback_callback(header: dict, message: dict) -> None:
                 if _transport_object:
                     _transport_object.transport.ack(header)
                 return None
-            if app_murfey := murfey_db.exec(
+            if not murfey_db.exec(
                 select(db.AutoProcProgram).where(db.AutoProcProgram.pj_id == pid)
             ).all():
-                appid = app_murfey[0].id
-            else:
                 if murfey.server.ispyb.Session() is None:
                     murfey_app = db.AutoProcProgram(pj_id=pid)
                 else:

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2813,7 +2813,7 @@ def feedback_callback(header: dict, message: dict) -> None:
                     dose_per_frame=message["dose_per_frame"],
                     gain_ref=(
                         str(machine_config.rsync_basepath / message["gain_ref"])
-                        if message["gain_ref"]
+                        if message["gain_ref"] and machine_config.data_transfer_enabled
                         else message["gain_ref"]
                     ),
                     voltage=message["voltage"],

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2629,7 +2629,7 @@ def feedback_callback(header: dict, message: dict) -> None:
                 # flush_data_collections(message["source"], murfey_db)
             else:
                 logger.warning(
-                    f"No data collection group ID was found for image directory {message['image_directory']} and source {message['source']}"
+                    f"No data collection group ID was found for image directory {sanitise(message['image_directory'])} and source {sanitise(message['source'])}"
                 )
                 if _transport_object:
                     _transport_object.transport.nack(header, requeue=True)
@@ -2701,7 +2701,9 @@ def feedback_callback(header: dict, message: dict) -> None:
             if dc:
                 _dcid = dc[0][0].id
             else:
-                logger.warning(f"No data collection ID found for {message['tag']}")
+                logger.warning(
+                    f"No data collection ID found for {sanitise(message['tag'])}"
+                )
                 if _transport_object:
                     _transport_object.transport.nack(header, requeue=True)
                 return None

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -1232,7 +1232,7 @@ async def request_tomography_preprocessing(
                 "fm_dose": proc_file.dose_per_frame,
                 "gain_ref": (
                     str(machine_config.rsync_basepath / proc_file.gain_ref)
-                    if proc_file.gain_ref
+                    if proc_file.gain_ref and machine_config.data_transfer_enabled
                     else proc_file.gain_ref
                 ),
                 "fm_int_file": proc_file.eer_fractionation_file,
@@ -1509,14 +1509,22 @@ async def write_eer_fractionation_file(
     machine_config = get_machine_config(instrument_name=instrument_name)[
         instrument_name
     ]
-    file_path = (
-        Path(machine_config.rsync_basepath)
-        / (machine_config.rsync_module or "data")
-        / str(datetime.datetime.now().year)
-        / secure_filename(visit_name)
-        / "processing"
-        / secure_filename(fractionation_params.fractionation_file_name)
-    )
+    if machine_config.eer_fractionation_file_template:
+        file_path = Path(
+            machine_config.eer_fractionation_file_template.format(
+                visit=secure_filename(visit_name),
+                year=str(datetime.datetime.now().year),
+            )
+        ) / secure_filename(fractionation_params.fractionation_file_name)
+    else:
+        file_path = (
+            Path(machine_config.rsync_basepath)
+            / (machine_config.rsync_module or "data")
+            / str(datetime.datetime.now().year)
+            / secure_filename(visit_name)
+            / "processing"
+            / secure_filename(fractionation_params.fractionation_file_name)
+        )
     if file_path.is_file():
         return {"eer_fractionation_file": str(file_path)}
 

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -167,8 +167,8 @@ def get_instrument_display_name(instrument_name: str) -> str:
     machine_config = get_machine_config(instrument_name=instrument_name)[
         instrument_name
     ]
-    if machine_config.get(instrument_name):
-        return machine_config[instrument_name].display_name
+    if machine_config:
+        return machine_config.display_name
     return ""
 
 

--- a/src/murfey/server/api/display.py
+++ b/src/murfey/server/api/display.py
@@ -13,10 +13,10 @@ router = APIRouter(prefix="/display", tags=["display"])
 machine_config = get_machine_config()
 
 
-@router.get("/microscope_image/")
-def get_mic_image():
-    if machine_config.image_path:
-        return FileResponse(machine_config.image_path)
+@router.get("/instruments/{instrument_name}/image/")
+def get_mic_image(instrument_name: str):
+    if machine_config[instrument_name].image_path:
+        return FileResponse(machine_config[instrument_name].image_path)
     return None
 
 

--- a/src/murfey/server/demo_api.py
+++ b/src/murfey/server/demo_api.py
@@ -843,26 +843,31 @@ def register_tilt(visit_name: str, client_id: int, tilt_info: TiltInfo, db=murfe
     db.commit()
 
 
+# @router.get("/instruments/{instrument_name}/visits_raw", response_model=List[Visit])
+# def get_current_visits(instrument_name: str):
+#     return [
+#         Visit(
+#             start=datetime.datetime.now(),
+#             end=datetime.datetime.now() + datetime.timedelta(days=1),
+#             session_id=1,
+#             name="cm31111-2",
+#             beamline="m12",
+#             proposal_title="Nothing of importance",
+#         ),
+#         Visit(
+#             start=datetime.datetime.now(),
+#             end=datetime.datetime.now() + datetime.timedelta(days=1),
+#             session_id=1,
+#             name="cm31111-3",
+#             beamline="m12",
+#             proposal_title="Nothing of importance",
+#         ),
+#     ]
+
+
 @router.get("/instruments/{instrument_name}/visits_raw", response_model=List[Visit])
-def get_current_visits(instrument_name: str):
-    return [
-        Visit(
-            start=datetime.datetime.now(),
-            end=datetime.datetime.now() + datetime.timedelta(days=1),
-            session_id=1,
-            name="cm31111-2",
-            beamline="m12",
-            proposal_title="Nothing of importance",
-        ),
-        Visit(
-            start=datetime.datetime.now(),
-            end=datetime.datetime.now() + datetime.timedelta(days=1),
-            session_id=1,
-            name="cm31111-3",
-            beamline="m12",
-            proposal_title="Nothing of importance",
-        ),
-    ]
+def get_current_visits(instrument_name: str, db=murfey.server.ispyb.DB):
+    return murfey.server.ispyb.get_all_ongoing_visits(instrument_name, db)
 
 
 @router.get("/visits/{visit_name}")

--- a/src/murfey/server/websocket.py
+++ b/src/murfey/server/websocket.py
@@ -137,7 +137,7 @@ async def websocket_connection_endpoint(
             except Exception:
                 await manager.broadcast(f"Client #{client_id} sent message {data}")
     except WebSocketDisconnect:
-        log.info(f"Disconnecting Client {int(sanitise(str(client_id)))}")
+        log.info(f"Disconnecting Client {sanitise(str(client_id))}")
         manager.disconnect(websocket, client_id, unregister_client=False)
         await manager.broadcast(f"Client #{client_id} disconnected")
         await manager.delete_state(f"Client {client_id}")

--- a/src/murfey/util/__init__.py
+++ b/src/murfey/util/__init__.py
@@ -64,7 +64,9 @@ def sanitise_nonpath(in_string: str) -> str:
 
 def secure_path(in_path: Path, keep_spaces: bool = False) -> Path:
     if keep_spaces:
-        secured_parts = [secure_filename(p) for p in in_path.parts if " " not in p]
+        secured_parts = [
+            secure_filename(p) if " " not in p else p for p in in_path.parts
+        ]
     else:
         secured_parts = [secure_filename(p) for p in in_path.parts]
     return Path("/".join(secured_parts))

--- a/src/murfey/util/__init__.py
+++ b/src/murfey/util/__init__.py
@@ -62,8 +62,11 @@ def sanitise_nonpath(in_string: str) -> str:
     return in_string
 
 
-def secure_path(in_path: Path) -> Path:
-    secured_parts = [secure_filename(p) for p in in_path.parts]
+def secure_path(in_path: Path, keep_spaces: bool = False) -> Path:
+    if keep_spaces:
+        secured_parts = [secure_filename(p) for p in in_path.parts if " " not in p]
+    else:
+        secured_parts = [secure_filename(p) for p in in_path.parts]
     return Path("/".join(secured_parts))
 
 

--- a/src/murfey/util/__init__.py
+++ b/src/murfey/util/__init__.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 import shutil
-from functools import lru_cache, partial
+from functools import partial
 from pathlib import Path
 from queue import Queue
 from threading import Thread
@@ -70,14 +70,6 @@ def secure_path(in_path: Path, keep_spaces: bool = False) -> Path:
     else:
         secured_parts = [secure_filename(p) for p in in_path.parts]
     return Path("/".join(secured_parts))
-
-
-@lru_cache(maxsize=1)
-def get_machine_config(url: str, instrument_name: str = "", demo: bool = False) -> dict:
-    _instrument_name: str | None = instrument_name or os.getenv("BEAMLINE")
-    if not _instrument_name:
-        return {}
-    return requests.get(f"{url}/instruments/{_instrument_name}/machine").json()
 
 
 def _get_visit_list(api_base: ParseResult, instrument_name: str):

--- a/src/murfey/util/__init__.py
+++ b/src/murfey/util/__init__.py
@@ -8,7 +8,7 @@ import json
 import logging
 import os
 import shutil
-from functools import partial
+from functools import lru_cache, partial
 from pathlib import Path
 from queue import Queue
 from threading import Thread
@@ -38,6 +38,16 @@ def read_config() -> configparser.ConfigParser:
     if "Murfey" not in config:
         config["Murfey"] = {}
     return config
+
+
+@lru_cache(maxsize=1)
+def get_machine_config_client(
+    url: str, instrument_name: str = "", demo: bool = False
+) -> dict:
+    _instrument_name: str | None = instrument_name or os.getenv("BEAMLINE")
+    if not _instrument_name:
+        return {}
+    return requests.get(f"{url}/instruments/{_instrument_name}/machine").json()
 
 
 def authorised_requests() -> Tuple[Callable, Callable, Callable, Callable]:

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -27,6 +27,7 @@ class MachineConfig(BaseModel):
     create_directories: Dict[str, str] = {"atlas": "atlas"}
     analyse_created_directories: List[str] = []
     gain_reference_directory: Optional[Path] = None
+    eer_fractionation_file_template: str = ""
     processed_directory_name: str = "processed"
     gain_directory_name: str = "processing"
     node_creator_queue: str = "node_creator"

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -35,6 +35,7 @@ class MachineConfig(BaseModel):
     data_required_substrings: Dict[str, Dict[str, List[str]]] = {}
     allow_removal: bool = False
     modular_spa: bool = False
+    data_transfer_enabled: bool = True
     processing_enabled: bool = True
     machine_override: str = ""
     processed_extra_directory: str = ""


### PR DESCRIPTION
ISPyB may not be in use at other facilities. This removes the requirement for a connection to an ISPyB database. The option to manually name visits is provided and data collection IDs etc. are autoincremented within the Murfey database when there is no ISPyB to interact with.