### PR TITLE
Removal of redundant tomography context code

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -38,7 +38,7 @@ def _get_tilt_angle_v5_11(p: Path) -> str:
 
 def _find_angle_index(split_name: List[str]) -> int:
     for i, part in enumerate(split_name):
-        if "." in part and part[0].isnumeric():
+        if "." in part and part[-1].isnumeric():
             return i
     return -1
 

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -117,7 +117,6 @@ class MurfeyInstanceEnvironment(BaseModel):
         self.autoproc_program_ids = {}
         self.data_collection_parameters = {}
         self.movies = {}
-        self.motion_corrected_movies = {}
         self.listeners = {}
         self.movie_tilt_pair = {}
         self.tilt_angles = {}

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -53,7 +53,6 @@ class MurfeyInstanceEnvironment(BaseModel):
     }
     data_collection_parameters: dict = {}
     movies: Dict[Path, MovieTracker] = {}
-    motion_corrected_movies: Dict[Path, List[str]] = {}
     listeners: Dict[str, Set[Callable]] = {}
     movie_tilt_pair: Dict[Path, str] = {}
     tilt_angles: Dict[str, List[List[str]]] = {}

--- a/tests/client/test_context.py
+++ b/tests/client/test_context.py
@@ -10,7 +10,7 @@ from murfey.client.instance_environment import MurfeyInstanceEnvironment
 
 def test_tomography_context_initialisation_for_tomo(tmp_path):
     context = TomographyContext("tomo", tmp_path)
-    assert not context._last_transferred_file
+    assert not context._completed_tilt_series
     assert context._acquisition_software == "tomo"
 
 
@@ -38,10 +38,6 @@ def test_tomography_context_add_tomo_tilt(mock_post, mock_get, tmp_path):
     assert context._tilt_series == {
         "Position_1": [tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"]
     }
-    assert (
-        context._last_transferred_file
-        == tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"
-    )
     (tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
         tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff",
@@ -101,10 +97,6 @@ def test_tomography_context_add_tomo_tilt_out_of_order(mock_post, mock_get, tmp_
     assert context._tilt_series == {
         "Position_1": [tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"]
     }
-    assert (
-        context._last_transferred_file
-        == tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"
-    )
     (tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
         tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff",
@@ -195,10 +187,6 @@ def test_tomography_context_add_tomo_tilt_delayed_tilt(mock_post, mock_get, tmp_
     assert context._tilt_series == {
         "Position_1": [tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"]
     }
-    assert (
-        context._last_transferred_file
-        == tmp_path / "Position_1_001_[30.0]_date_time_fractions.tiff"
-    )
     (tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff").touch()
     context.post_transfer(
         tmp_path / "Position_1_002_[-30.0]_date_time_fractions.tiff",
@@ -236,7 +224,7 @@ def test_tomography_context_add_tomo_tilt_delayed_tilt(mock_post, mock_get, tmp_
 
 def test_tomography_context_initialisation_for_serialem(tmp_path):
     context = TomographyContext("serialem", tmp_path)
-    assert not context._last_transferred_file
+    assert not context._completed_tilt_series
     assert context._acquisition_software == "serialem"
 
 


### PR DESCRIPTION
This aims to fix the problems we see where late-started tomography sessions don't run alignment on some tomograms.

In that case the tilt series is never marked as completed by the client, so alignment cannot be run. I've removed a lot of unused or redundant code, and simplified the calls for checking tilt series completion. The completion check is now always run when a tilt is added.