### PR TITLE
Fixed metadata behaviour after bumping to SQLAlchemy v2

### DIFF
--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -757,7 +757,7 @@ def setup(url: str):
 
 def clear(url: str):
     engine = create_engine(url)
-    metadata = sqlalchemy.MetaData(engine)
-    metadata.reflect()
-
+    metadata = sqlalchemy.MetaData()
+    metadata.create_all(engine)
+    metadata.reflect(engine)
     metadata.drop_all(engine)


### PR DESCRIPTION
Fast forwarding this fix from the Pydantic v2 PR because it's a one-liner and is breaking functionality now that we've upgraded to SQLAlchemy v2.

- [x] Able to create Murfey database on workstation
- [x] Able to run Murfey server
- [x] Able to get and post entries to the database