### PR TITLE
Removed explicit exit() from Textual-related classes and functions

### DIFF
--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -718,7 +718,6 @@ class MurfeyTUI(App):
         if self._multigrid_watcher:
             self._multigrid_watcher.stop()
         self.exit()
-        exit()
 
     async def action_remove_session(self) -> None:
         requests.delete(
@@ -733,14 +732,12 @@ class MurfeyTUI(App):
         if self._multigrid_watcher:
             self._multigrid_watcher.stop()
         self.exit()
-        exit()
 
     def clean_up_quit(self) -> None:
         requests.delete(
             f"{self._environment.url.geturl()}/instruments/{self._environment.instrument_name}/clients/{self._environment.client_id}/session"
         )
         self.exit()
-        exit()
 
     async def action_clear(self) -> None:
         machine_config = get_machine_config_client(
@@ -787,7 +784,6 @@ class MurfeyTUI(App):
             f"{self._environment.url.geturl()}/instruments/{self._environment.instrument_name}/clients/{self._environment.client_id}/session"
         )
         self.exit()
-        exit()
 
     async def action_process(self) -> None:
         self.processing_btn.disabled = False

--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -1204,7 +1204,6 @@ class WaitingScreen(Screen):
                 f"{self.app._environment.url.geturl()}/instruments/{self._environment.instrument_name}/clients/{self.app._environment.client_id}/session"
             )
             self.app.exit()
-            exit()
 
 
 class MainScreen(Screen):


### PR DESCRIPTION
When referring to the Textual demo app, it does not once call an explicit `exit()`, relying instead on `self.exit()` to close itself. This seems to be the cause of the raised I/OErrors when we try to quit the Murfey app.

Credits to: @stephen-riggs 