### PR TITLE
Support tomography with only a single tilt

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -67,6 +67,8 @@ def _construct_tilt_series_name(file_path: Path) -> str:
 def _midpoint(angles: List[float]) -> int:
     if not angles:
         return 0
+    if len(angles) <= 2:
+        return round(angles[0])
     sorted_angles = sorted(angles)
     return round(
         sorted_angles[len(sorted_angles) // 2]

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2511,6 +2511,7 @@ def feedback_callback(header: dict, message: dict) -> None:
             if (
                 check_tilt_series_mc(relevant_tilt_series.id)
                 and not relevant_tilt_series.processing_requested
+                and relevant_tilt_series.tilt_series_length > 2
             ):
                 relevant_tilt_series.processing_requested = True
                 murfey_db.add(relevant_tilt_series)

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -736,7 +736,11 @@ def register_completed_tilt_series(
         db.add(ts)
     db.commit()
     for ts in tilt_series_db:
-        if check_tilt_series_mc(ts.id) and not ts.processing_requested:
+        if (
+            check_tilt_series_mc(ts.id)
+            and not ts.processing_requested
+            and ts.tilt_series_length > 2
+        ):
             ts.processing_requested = True
             db.add(ts)
 


### PR DESCRIPTION
Tomography processing currently fails if there are less than three tilts.
From what I can see, this is just due to trying to find the midpoint. If this can't be found I suggest we return the first angle.

Closes #239 