### PR TITLE
Make machine configuration extendable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,8 @@ murfey = "murfey.client:run"
 "murfey.transfer" = "murfey.cli.transfer:run"
 [project.entry-points."murfey.auth.token_validation"]
 "password" = "murfey.server.api.auth:password_token_validation"
+[project.entry-points."murfey.config.extraction"]
+"murfey_machine" = "murfey.util.config:get_extended_machine_config"
 [project.entry-points."murfey.workflows"]
 "lif_to_stack" = "murfey.workflows.lif_to_stack:zocalo_cluster_request"
 "tiff_to_stack" = "murfey.workflows.tiff_to_stack:zocalo_cluster_request"

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -164,7 +164,7 @@ def get_extended_machine_config(
     extension_name: str, instrument_name: str = ""
 ) -> Optional[BaseModel]:
     machine_config = get_machine_config(instrument_name=instrument_name).get(
-        instrument_name
+        instrument_name or get_microscope()
     )
     if not machine_config:
         return None

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional, Union
 
 import yaml
+from backports.entry_points_selectable import entry_points
 from pydantic import BaseModel, BaseSettings
 
 
@@ -157,3 +158,16 @@ def get_machine_config(instrument_name: str = "") -> Dict[str, MachineConfig]:
             Path(settings.murfey_machine_configuration), microscope
         )
     return machine_config
+
+
+def get_extended_machine_config(
+    extension_name: str, instrument_name: str = ""
+) -> Optional[BaseModel]:
+    machine_config = get_machine_config(instrument_name=instrument_name).get(
+        instrument_name
+    )
+    if not machine_config:
+        return None
+    model = entry_points.select(group="murfey.config", name=extension_name)[0].load()
+    data = getattr(machine_config, extension_name, {})
+    return model(data)

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -8,10 +8,10 @@ from typing import Dict, List, Literal, Optional, Union
 
 import yaml
 from backports.entry_points_selectable import entry_points
-from pydantic import BaseModel, BaseSettings
+from pydantic import BaseModel, BaseSettings, Extra
 
 
-class MachineConfig(BaseModel):
+class MachineConfig(BaseModel, extra=Extra.allow):  # type: ignore
     acquisition_software: List[str]
     calibrations: Dict[str, Dict[str, Union[dict, float]]]
     data_directories: Dict[Path, str]


### PR DESCRIPTION
Allow extra configuration options to be extracted from the Murfey machine configuration and validated against a pydantic model specified as an entry point. This allows external packages to add their configuration to the Murfey config for convenience