### PR TITLE
CLEM workflow bug fixes

### DIFF
--- a/src/murfey/client/contexts/clem.py
+++ b/src/murfey/client/contexts/clem.py
@@ -164,7 +164,7 @@ class CLEMContext(Context):
                 # Create a unique name for the series
                 # For standard file name
                 if len(transferred_file.stem.split("--")) == 3:
-                    series_name = "/".join(
+                    series_name = "--".join(
                         [
                             *destination_file.parent.parts[
                                 -2:
@@ -174,7 +174,7 @@ class CLEMContext(Context):
                     )
                 # When this a repeated position
                 elif len(transferred_file.stem.split("--")) == 4:
-                    series_name = "/".join(
+                    series_name = "--".join(
                         [
                             *destination_file.parent.parts[
                                 -2:
@@ -217,7 +217,8 @@ class CLEMContext(Context):
                     )
                     return True
 
-                # Skip processing of "IOManagerConfiguation.xlif" files (yes, the typo IS part of the file name)
+                # Skip processing of "IOManagerConfiguation.xlif" files
+                #   YES, the 'Configuation' typo IS part of the file name
                 if "IOManagerConfiguation" in transferred_file.stem:
                     logger.debug(
                         f"File {transferred_file.name!r} is a Leica configuration file; skipping processing"
@@ -231,7 +232,7 @@ class CLEMContext(Context):
                 # Create series name for XLIF file
                 # XLIF files don't have the "--ZXX--CXX" additions in the file name
                 # But they have "/Metadata/" as the immediate parent
-                series_name = "/".join(
+                series_name = "--".join(
                     [*destination_file.parent.parent.parts[-2:], destination_file.stem]
                 )  # The previous 2 parent directories should be unique enough
                 logger.debug(

--- a/src/murfey/workflows/clem/process_raw_tiffs.py
+++ b/src/murfey/workflows/clem/process_raw_tiffs.py
@@ -24,7 +24,9 @@ def zocalo_cluster_request(
 ):
     if messenger:
         # Construct path to session directory
-        path_parts = list(tiff_list[0].parts)
+        path_parts = list(
+            (tiff_list[0].parent / (tiff_list[0].stem.split("--")[0])).parts
+        )
         # Replace leading "/" in Unix paths
         path_parts[0] = "" if path_parts[0] == "/" else path_parts[0]
         try:


### PR DESCRIPTION
* Removed the '--Zxx--Cxx.tif' part of the file name before parsing the file path to generate a job name. Resolves issue #407.
* Replaces '/' with '--' when generating series names to group the TIFF files under while parsing the transferred data.