### PR TITLE
Optional configuration of rsync daemon host

### DIFF
--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -31,6 +31,7 @@ class MultigridController:
     instrument_name: str
     session_id: int
     murfey_url: str = "http://localhost:8000"
+    rsync_url: str = ""
     demo: bool = False
     processing_enabled: bool = True
     do_transfer: bool = True
@@ -57,6 +58,7 @@ class MultigridController:
         machine_data = requests.get(
             f"{self.murfey_url}/instruments/{self.instrument_name}/machine"
         ).json()
+        self.rsync_url = machine_data.get("rsync_url", "")
         self._environment = MurfeyInstanceEnvironment(
             url=urlparse(self.murfey_url, allow_fragments=False),
             client_id=0,
@@ -209,7 +211,11 @@ class MultigridController:
             self.rsync_processes[source] = RSyncer(
                 source,
                 basepath_remote=Path(destination),
-                server_url=self._environment.url,
+                server_url=(
+                    urlparse(self.rsync_url)
+                    if self.rsync_url
+                    else self._environment.url
+                ),
                 stop_callback=self._rsyncer_stopped,
                 do_transfer=self.do_transfer,
                 remove_files=remove_files,

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -187,6 +187,7 @@ class MurfeyTUI(App):
             remove_files=remove_files,
             limited=limited,
             transfer=machine_data.get("data_transfer_enabled", True),
+            rsync_url=machine_data.get("rsync_url", ""),
         )
 
     def _start_rsyncer(
@@ -199,6 +200,7 @@ class MurfeyTUI(App):
         remove_files: bool = False,
         limited: bool = False,
         transfer: bool = True,
+        rsync_url: str = "",
     ):
         log.info(f"starting rsyncer: {source}")
         if self._environment:
@@ -226,7 +228,7 @@ class MurfeyTUI(App):
             self.rsync_processes[source] = RSyncer(
                 source,
                 basepath_remote=Path(destination),
-                server_url=self._url,
+                server_url=urlparse(rsync_url) if rsync_url else self._url,
                 # local=self._environment.demo,
                 status_bar=self._statusbar,
                 do_transfer=self._do_transfer,

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -66,6 +66,7 @@ class MachineConfig(BaseModel, extra=Extra.allow):  # type: ignore
     instrument_server_url: str = "http://localhost:8001"
     frontend_url: str = "http://localhost:3000"
     murfey_url: str = "http://localhost:8000"
+    rsync_url: str = ""
 
     security_configuration_path: Optional[Path] = None
     auth_url: str = ""


### PR DESCRIPTION
Currently the server hosting the rsync daemon used for transfer is always assumed to be the same as that hosting the Murfey server. It is possible that these would be two different hosts which would then require two URLs. Here an `rsync_url` configuration option is added. If left at its default value of `""` the Murfey server URL will be used, otherwise the configured value is used.