### PR TITLE
Make directories on starting rsyncers

### DIFF
--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -186,6 +186,12 @@ class MultigridController:
         restarted: bool = False,
     ):
         log.info(f"starting rsyncer: {source}")
+        if transfer:
+            # Always make sure the destination directory exists
+            make_directory_url = (
+                f"{self.murfey_url}/sessions/{self.session_id}/make_rsyncer_destination"
+            )
+            capture_post(make_directory_url, json={"destination": destination})
         if self._environment:
             self._environment.default_destinations[source] = destination
             if self._environment.gain_ref and visit_path:

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -203,6 +203,10 @@ class MurfeyTUI(App):
         rsync_url: str = "",
     ):
         log.info(f"starting rsyncer: {source}")
+        if transfer:
+            # Always make sure the destination directory exists
+            make_directory_url = f"{str(self._url.geturl())}/sessions/{str(self._environment.murfey_session)}/make_rsyncer_destination"
+            capture_post(make_directory_url, json={"destination": destination})
         if self._environment:
             self._environment.default_destinations[source] = destination
             if self._environment.gain_ref and visit_path:


### PR DESCRIPTION
A suggested fix for the problem seen last week where metadata directories were not made after they were input manually.
This would explicitly make the full directory structure whenever an rsyncer is started.