### PR TITLE
Register tilt series as completed if they have more tilts than the mdoc

### DIFF
--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -116,7 +116,8 @@ def check_tilt_series_mc(tilt_series_id: int) -> bool:
     ).all()
     return (
         all(r[0].motion_corrected for r in results)
-        and len(results) == results[0][1].tilt_series_length
+        and len(results) >= results[0][1].tilt_series_length
+        and results[0][1].tilt_series_length > 0
     )
 
 


### PR DESCRIPTION
A fix for the problem where a user cancelling and restarting a tilt series leads to the number of tilt files exceeding the number in the mdoc.

The tomo context already considers a series to be complete if it has more tilts than in the mdoc, but the motion correction check did not.