### PR TITLE
Removed unused table columns from CLEM PostgreSQL tables

### DIFF
--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -272,8 +272,6 @@ class CLEMImageSeries(SQLModel, table=True):  # type: ignore
     number_of_members: int = (
         0  # Expected number of image stacks belonging to this series
     )
-    images_aligned: bool = False  # Have all members been aligned?
-    rgbs_created: bool = False  # Have all members been colourised?
     composite_created: bool = False  # Has a composite image been created?
     composite_image: Optional[str] = None  # Full path to composite image
 
@@ -321,13 +319,6 @@ class CLEMImageStack(SQLModel, table=True):  # type: ignore
         foreign_key="clemimageseries.id",
         default=None,
     )
-
-    # Process checklist for each image
-    stack_created: bool = False  # Verify that the stack has been created
-    image_aligned: bool = False  # Verify that image alignment has been done on stack
-    aligned_image: Optional[str] = None  # Full path to aligned image stack
-    rgb_created: bool = False  # Verify that rgb image has been created
-    rgb_image: Optional[str] = None  # Full path to colorised image stack
 
 
 """

--- a/src/murfey/workflows/clem/register_preprocessing_results.py
+++ b/src/murfey/workflows/clem/register_preprocessing_results.py
@@ -120,7 +120,6 @@ def register_lif_preprocessing_result(
             clem_img_stk.parent_lif = clem_lif_file
             clem_img_stk.parent_series = clem_img_series
             clem_img_stk.channel_name = result.channel
-            clem_img_stk.stack_created = True
             db.add(clem_img_stk)
             db.commit()
             db.refresh(clem_img_stk)
@@ -309,7 +308,6 @@ def register_tiff_preprocessing_result(
             clem_img_stk.associated_metadata = clem_metadata
             clem_img_stk.parent_series = clem_img_series
             clem_img_stk.channel_name = result.channel
-            clem_img_stk.stack_created = True
             db.add(clem_img_stk)
             db.commit()
             db.refresh(clem_img_stk)


### PR DESCRIPTION
Now that the CLEM workflow has matured a bit, some columns in the CLEM database tables have been verified to be not necessary. This PR removes them.