### PR TITLE
Load RabbitMQ credentials directly using PikaTransport object

### DIFF
--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -11,7 +11,7 @@ from functools import partial, singledispatch
 from importlib.resources import files
 from pathlib import Path
 from threading import Thread
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import Any, Dict, List, Literal, NamedTuple, Tuple
 
 import graypy
 import mrcfile
@@ -296,7 +296,7 @@ def run():
     else:
         # Load RabbitMQ configuration and set up the connection
         PikaTransport().load_configuration_file(security_config.rabbitmq_credentials)
-        _set_up_transport("pika")
+        _set_up_transport("PikaTransport")
 
     # Set up logging now that the desired verbosity is known
     _set_up_logging(quiet=args.quiet, verbosity=args.verbose)
@@ -395,7 +395,7 @@ def _set_up_logging(quiet: bool, verbosity: int):
         logging.getLogger(logger_name).setLevel(log_level)
 
 
-def _set_up_transport(transport_type):
+def _set_up_transport(transport_type: Literal["PikaTransport"]):
     global _transport_object
     _transport_object = TransportManager(transport_type)
 

--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import logging
 import os
-from typing import Callable, List, Optional
+from typing import Callable, List, Literal, Optional
 
 import ispyb
 
@@ -55,7 +55,7 @@ def _send_using_new_connection(transport_type: str, queue: str, message: dict) -
 
 
 class TransportManager:
-    def __init__(self, transport_type):
+    def __init__(self, transport_type: Literal["PikaTransport"]):
         self._transport_type = transport_type
         self.transport = workflows.transport.lookup(transport_type)()
         self.transport.connect()


### PR DESCRIPTION
Now that we've removed the Zocalo configuration dependency, we import and use PikaTransport directly to load the RabbitMQ configuration