### PR TITLE
Resolved client-server interdependence when running a Murfey server

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -21,6 +21,7 @@ from murfey.client.instance_environment import (
 )
 from murfey.util import authorised_requests, capture_post, get_machine_config_client
 from murfey.util.mdoc import get_block, get_global_data, get_num_blocks
+from murfey.util.tomo import midpoint
 
 logger = logging.getLogger("murfey.client.contexts.tomo")
 
@@ -62,20 +63,6 @@ def _construct_tilt_series_name(file_path: Path) -> str:
     # Assuming files end with _{tiltnumber}_{angle}_{date}_{time}_{fractions}.{suffix}
     split_name = file_path.name.split("_")
     return "_".join(split_name[:-5])
-
-
-def _midpoint(angles: List[float]) -> int:
-    if not angles:
-        return 0
-    if len(angles) <= 2:
-        return round(angles[0])
-    sorted_angles = sorted(angles)
-    return round(
-        sorted_angles[len(sorted_angles) // 2]
-        if sorted_angles[len(sorted_angles) // 2]
-        and sorted_angles[len(sorted_angles) // 2 + 1]
-        else 0
-    )
 
 
 class ProcessFileIncomplete(BaseModel):
@@ -738,7 +725,7 @@ class TomographyContext(Context):
                 if environment
                 else None
             )
-            mdoc_metadata["manual_tilt_offset"] = -_midpoint(
+            mdoc_metadata["manual_tilt_offset"] = -midpoint(
                 [float(b["TiltAngle"]) for b in blocks]
             )
             mdoc_metadata["source"] = str(self._basepath)

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -59,6 +59,7 @@ from murfey.util.config import (
 )
 from murfey.util.processing_params import default_spa_parameters
 from murfey.util.state import global_state
+from murfey.util.tomo import midpoint
 
 try:
     from murfey.server.ispyb import TransportManager  # Session
@@ -162,24 +163,6 @@ def get_all_tilts(tilt_series_id: int) -> List[str]:
         return str(mrc_out)
 
     return [_mc_path(Path(r.movie_path)) for r in results]
-
-
-def _midpoint(angles: List[float]) -> int:
-    """
-    Duplicate of the function in 'murfey.client.contexts.tomo', so as to preserve
-    client-server independence.
-    """
-    if not angles:
-        return 0
-    if len(angles) <= 2:
-        return round(angles[0])
-    sorted_angles = sorted(angles)
-    return round(
-        sorted_angles[len(sorted_angles) // 2]
-        if sorted_angles[len(sorted_angles) // 2]
-        and sorted_angles[len(sorted_angles) // 2 + 1]
-        else 0
-    )
 
 
 def get_job_ids(tilt_series_id: int, appid: int) -> JobIDs:
@@ -2593,7 +2576,7 @@ def feedback_callback(header: dict, message: dict) -> None:
                 )
                 if not stack_file.parent.exists():
                     stack_file.parent.mkdir(parents=True)
-                tilt_offset = _midpoint([float(get_angle(t)) for t in tilts])
+                tilt_offset = midpoint([float(get_angle(t)) for t in tilts])
                 zocalo_message = {
                     "recipes": ["em-tomo-align"],
                     "parameters": {

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -33,7 +33,6 @@ import murfey.server.prometheus as prom
 import murfey.server.websocket as ws
 import murfey.util.eer
 from murfey.server import (
-    _midpoint,
     _murfey_id,
     _transport_object,
     check_tilt_series_mc,
@@ -108,6 +107,7 @@ from murfey.util.models import (
 )
 from murfey.util.processing_params import default_spa_parameters
 from murfey.util.state import global_state
+from murfey.util.tomo import midpoint
 
 log = logging.getLogger("murfey.server.api")
 
@@ -840,7 +840,7 @@ def register_completed_tilt_series(
             )
             if not stack_file.parent.exists():
                 stack_file.parent.mkdir(parents=True)
-            tilt_offset = _midpoint([float(get_angle(t)) for t in tilts])
+            tilt_offset = midpoint([float(get_angle(t)) for t in tilts])
             zocalo_message = {
                 "recipes": ["em-tomo-align"],
                 "parameters": {

--- a/src/murfey/util/tomo.py
+++ b/src/murfey/util/tomo.py
@@ -1,0 +1,16 @@
+def midpoint(angles: list[float]) -> int:
+    """
+    Utility function to calculate the midpoint of the angles used in a tilt series.
+    Used primarily in the tomography workflow.
+    """
+    if not angles:
+        return 0
+    if len(angles) <= 2:
+        return round(angles[0])
+    sorted_angles = sorted(angles)
+    return round(
+        sorted_angles[len(sorted_angles) // 2]
+        if sorted_angles[len(sorted_angles) // 2]
+        and sorted_angles[len(sorted_angles) // 2 + 1]
+        else 0
+    )


### PR DESCRIPTION
Partially resolves issue #446 .

`murfey.client.contexts.tomo._midpoint` was imported and used once in `murfey.server.__init__`. This causes the modules in `murfey.client` to be initialised, leading to a dependency chain where the client-side dependencies have to be installed just to run the server modules.

By duplicating the `_midpoint` function in `murfey.server.__init__`, this breaks that import chain.

EDIT: A better solution has been to move the `midpoint()` function over to `murfey.util.__init__`, which breaks that import chain