### PR TITLE
'xmltodict' is now used on both client and server sides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "requests",
     "rich",
     "werkzeug",
+    "xmltodict",
 ]
 [project.optional-dependencies]
 cicd = [
@@ -44,7 +45,6 @@ cicd = [
 client = [
     "textual==0.42.0",
     "websocket-client",
-    "xmltodict",
 ]
 developer = [
     "bump-my-version<0.11.0", # Version control


### PR DESCRIPTION
Found this error when installing just the server side of Murfey. `xmltodict` was imported for use in `murfey.util.spa_metadata`.