### PR TITLE
Remove the client-side stashing for tomography

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -252,24 +252,16 @@ class TomographyContext(Context):
                     capture_post(dc_url, json=dc_data)
 
                     proc_url = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.murfey_session}/register_processing_job"
-                    capture_post(
-                        proc_url,
-                        json={
-                            "tag": tilt_series,
-                            "source": str(self._basepath),
-                            "recipe": "em-tomo-preprocess",
-                            "experiment_type": "tomography",
-                        },
-                    )
-                    capture_post(
-                        proc_url,
-                        json={
-                            "tag": tilt_series,
-                            "source": str(self._basepath),
-                            "recipe": "em-tomo-align",
-                            "experiment_type": "tomography",
-                        },
-                    )
+                    for recipe in ("em-tomo-preprocess", "em-tomo-align"):
+                        capture_post(
+                            proc_url,
+                            json={
+                                "tag": tilt_series,
+                                "source": str(self._basepath),
+                                "recipe": recipe,
+                                "experiment_type": "tomography",
+                            },
+                        )
 
             except Exception as e:
                 logger.error(f"ERROR {e}, {environment.data_collection_parameters}")

--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -41,7 +41,6 @@ class MurfeyInstanceEnvironment(BaseModel):
     destination_registry: Dict[str, str] = {}
     watchers: Dict[Path, DirWatcher] = {}
     demo: bool = False
-    data_collection_group_ids: Dict[str, int] = {}
     data_collection_parameters: dict = {}
     movies: Dict[Path, MovieTracker] = {}
     movie_tilt_pair: Dict[Path, str] = {}
@@ -64,7 +63,6 @@ class MurfeyInstanceEnvironment(BaseModel):
         for w in self.watchers.values():
             w.stop()
         self.watchers = {}
-        self.data_collection_group_ids = {}
         self.data_collection_parameters = {}
         self.movies = {}
         self.movie_tilt_pair = {}

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -369,46 +369,6 @@ class MultigridController:
                 )
 
             source = Path(json["source"])
-
-            url = f"{str(self._environment.url.geturl())}/visits/{str(self._environment.visit)}/{self.session_id}/register_data_collection_group"
-            dcg_data = {
-                "experiment_type": "tomo",
-                "experiment_type_id": 36,
-                "tag": str(source),
-            }
-            requests.post(url, json=dcg_data)
-
-            data = {
-                "voltage": json["voltage"],
-                "pixel_size_on_image": json["pixel_size_on_image"],
-                "experiment_type": json["experiment_type"],
-                "image_size_x": json["image_size_x"],
-                "image_size_y": json["image_size_y"],
-                "file_extension": json["file_extension"],
-                "acquisition_software": json["acquisition_software"],
-                "image_directory": str(self._environment.default_destinations[source]),
-                "tag": json["tilt_series_tag"],
-                "source": str(source),
-                "magnification": json["magnification"],
-                "total_exposed_dose": json.get("total_exposed_dose"),
-                "c2aperture": json.get("c2aperture"),
-                "exposure_time": json.get("exposure_time"),
-                "slit_width": json.get("slit_width"),
-                "phase_plate": json.get("phase_plate", False),
-            }
-            capture_post(
-                f"{str(self._environment.url.geturl())}/visits/{str(self._environment.visit)}/{self._environment.murfey_session}/start_data_collection",
-                json=data,
-            )
-            for recipe in ("em-tomo-preprocess", "em-tomo-align"):
-                capture_post(
-                    f"{str(self._environment.url.geturl())}/visits/{str(self._environment.visit)}/{self._environment.murfey_session}/register_processing_job",
-                    json={
-                        "tag": json["tilt_series_tag"],
-                        "source": str(source),
-                        "recipe": recipe,
-                    },
-                )
             log.info("Registering tomography processing parameters")
             if self._environment.data_collection_parameters.get("num_eer_frames"):
                 eer_response = requests.post(
@@ -432,8 +392,6 @@ class MultigridController:
                 f"{self._environment.url.geturl()}/sessions/{self._environment.murfey_session}/tomography_preprocessing_parameters",
                 json=json,
             )
-            context._flush_data_collections()
-            context._flush_processing_jobs()
             capture_post(
                 f"{self._environment.url.geturl()}/visits/{self._environment.visit}/{self._environment.murfey_session}/flush_tomography_processing",
                 json={"rsync_source": str(source)},

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -474,54 +474,6 @@ class MurfeyTUI(App):
         context = self.analysers[source]._context
         if isinstance(context, TomographyContext):
             source = Path(json["source"])
-            url = f"{str(self._url.geturl())}/visits/{str(self._visit)}/{self._environment.murfey_session}/register_data_collection_group"
-            dcg_data = {
-                "experiment_type": "tomo",
-                "experiment_type_id": 36,
-                "tag": str(source),
-                "atlas": (
-                    str(self._environment.samples[source].atlas)
-                    if self._environment.samples.get(source)
-                    else ""
-                ),
-                "sample": (
-                    self._environment.samples[source].sample
-                    if self._environment.samples.get(source)
-                    else None
-                ),
-            }
-            capture_post(url, json=dcg_data)
-            data = {
-                "voltage": json["voltage"],
-                "pixel_size_on_image": json["pixel_size_on_image"],
-                "experiment_type": json["experiment_type"],
-                "image_size_x": json["image_size_x"],
-                "image_size_y": json["image_size_y"],
-                "file_extension": json["file_extension"],
-                "acquisition_software": json["acquisition_software"],
-                "image_directory": str(self._environment.default_destinations[source]),
-                "tag": json["tilt_series_tag"],
-                "source": str(source),
-                "magnification": json["magnification"],
-                "total_exposed_dose": json.get("total_exposed_dose"),
-                "c2aperture": json.get("c2aperture"),
-                "exposure_time": json.get("exposure_time"),
-                "slit_width": json.get("slit_width"),
-                "phase_plate": json.get("phase_plate", False),
-            }
-            capture_post(
-                f"{str(self._url.geturl())}/visits/{str(self._visit)}/{self._environment.murfey_session}/start_data_collection",
-                json=data,
-            )
-            for recipe in ("em-tomo-preprocess", "em-tomo-align"):
-                capture_post(
-                    f"{str(self._url.geturl())}/visits/{str(self._visit)}/{self._environment.murfey_session}/register_processing_job",
-                    json={
-                        "tag": json["tilt_series_tag"],
-                        "source": str(source),
-                        "recipe": recipe,
-                    },
-                )
             log.info("Registering tomography processing parameters")
             if self.app._environment.data_collection_parameters.get("num_eer_frames"):
                 eer_response = requests.post(
@@ -545,8 +497,6 @@ class MurfeyTUI(App):
                 f"{self.app._environment.url.geturl()}/sessions/{self.app._environment.murfey_session}/tomography_preprocessing_parameters",
                 json=json,
             )
-            context._flush_data_collections()
-            context._flush_processing_jobs()
             capture_post(
                 f"{self.app._environment.url.geturl()}/visits/{self._visit}/{self.app._environment.murfey_session}/flush_tomography_processing",
                 json={"rsync_source": str(source)},


### PR DESCRIPTION
The client still stores a stash of data collection and processing job calls for tomography before the first mdoc is seen.
However, the server already has a preprocess stash for tomography, so the client one is not needed any more.

This removes the client stash, and just sends all requests on to the server.