### PR TITLE
Get the longest source, and log failed Images-Disc searches

### DIFF
--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -79,10 +79,19 @@ def _grid_square_metadata_file(
 
 
 def _get_source(file_path: Path, environment: MurfeyInstanceEnvironment) -> Path | None:
+    possible_sources = []
     for s in environment.sources:
         if file_path.is_relative_to(s):
-            return s
-    return None
+            possible_sources.append(s)
+    if not possible_sources:
+        return None
+    elif len(possible_sources) == 1:
+        return possible_sources[0]
+    source = possible_sources[0]
+    for extra_source in possible_sources[1:]:
+        if extra_source.is_relative_to(source):
+            source = extra_source
+    return source
 
 
 def _get_xml_list_index(key: str, xml_list: list) -> int:

--- a/src/murfey/client/contexts/spa_metadata.py
+++ b/src/murfey/client/contexts/spa_metadata.py
@@ -151,16 +151,16 @@ class SPAMetadataContext(Context):
                 )
                 url = f"{str(environment.url.geturl())}/visits/{environment.visit}/{environment.murfey_session}/register_data_collection_group"
                 dcg_search_dir = "/".join(
-                    p
-                    for p in transferred_file.parent.parts[1:]
-                    if p != environment.visit
+                    p for p in transferred_file.parent.parts if p != environment.visit
                 )
-                dcg_tag = str(
-                    sorted(
-                        Path(dcg_search_dir).glob("Images-Disc*"),
-                        key=lambda x: x.stat().st_ctime,
-                    )[-1]
+                dcg_images_dirs = sorted(
+                    Path(dcg_search_dir).glob("Images-Disc*"),
+                    key=lambda x: x.stat().st_ctime,
                 )
+                if not dcg_images_dirs:
+                    logger.warning(f"Cannot find Images-Disc* in {dcg_search_dir}")
+                    return
+                dcg_tag = str(dcg_images_dirs[-1])
                 dcg_data = {
                     "experiment_type": "single particle",
                     "experiment_type_id": 37,
@@ -206,12 +206,16 @@ class SPAMetadataContext(Context):
             visitless_source_search_dir = str(source).replace(
                 f"/{environment.visit}", ""
             )
-            visitless_source = str(
-                sorted(
-                    Path(visitless_source_search_dir).glob("Images-Disc*"),
-                    key=lambda x: x.stat().st_ctime,
-                )[-1]
+            visitless_source_images_dirs = sorted(
+                Path(visitless_source_search_dir).glob("Images-Disc*"),
+                key=lambda x: x.stat().st_ctime,
             )
+            if not visitless_source_images_dirs:
+                logger.warning(
+                    f"Cannot find Images-Disc* in {visitless_source_search_dir}"
+                )
+                return
+            visitless_source = str(visitless_source_images_dirs[-1])
             for fh, fh_data in fh_positions.items():
                 capture_post(
                     f"{str(environment.url.geturl())}/sessions/{environment.murfey_session}/grid_square/{gs_name}/foil_hole",


### PR DESCRIPTION
The globs for `Images-Disc*` were not working, and this attempts to fix them again. If they fail, it logs the directory being searched.