### PR TITLE
Restore code to register tomo data collections post mdoc

### DIFF
--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -377,6 +377,12 @@ class MultigridController:
                 )
 
             source = Path(json["source"])
+            context.register_tomography_data_collections(
+                file_extension=json["file_extension"],
+                image_directory=str(self._environment.default_destinations[source]),
+                environment=self._environment,
+            )
+
             log.info("Registering tomography processing parameters")
             if self._environment.data_collection_parameters.get("num_eer_frames"):
                 eer_response = requests.post(

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -478,6 +478,12 @@ class MurfeyTUI(App):
         context = self.analysers[source]._context
         if isinstance(context, TomographyContext):
             source = Path(json["source"])
+            context.register_tomography_data_collections(
+                file_extension=json["file_extension"],
+                image_directory=str(self._environment.default_destinations[source]),
+                environment=self._environment,
+            )
+
             log.info("Registering tomography processing parameters")
             if self.app._environment.data_collection_parameters.get("num_eer_frames"):
                 eer_response = requests.post(


### PR DESCRIPTION
Rather than the old method of stashing all the calls to make, this loops over all tilt series and checks if they can be registered.