### PR TITLE
Added CLI to automate building of Docker images

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ GitHub = "https://github.com/DiamondLightSource/python-murfey"
 [project.scripts]
 murfey = "murfey.client:run"
 "murfey.add_user" = "murfey.cli.add_user:run"
+"murfey.build_images" = "murfey.cli.build_images:run"
 "murfey.create_db" = "murfey.cli.create_db:run"
 "murfey.db_sql" = "murfey.cli.murfey_db_sql:run"
 "murfey.decrypt_password" = "murfey.cli.decrypt_db_password:run"

--- a/src/murfey/cli/build_images.py
+++ b/src/murfey/cli/build_images.py
@@ -288,7 +288,7 @@ def run():
             images.extend(new_tags)
 
     # Push all built images to specified repo
-    push_images(images, dry_run=args.dry_run)
+    push_images(images=images, dry_run=args.dry_run)
 
     # Perform final cleanup
     cleanup(dry_run=args.dry_run)

--- a/src/murfey/cli/build_images.py
+++ b/src/murfey/cli/build_images.py
@@ -1,0 +1,304 @@
+"""
+Helper function to automate the process of building and publishing Docker images for
+Murfey using Python subprocesses.
+
+This CLI is designed to run with Podman commands and in a bash shell that has been
+configured to push to a valid Docker repo, which has to be specified using a flag.
+"""
+
+import grp
+import os
+import subprocess
+from argparse import ArgumentParser
+from pathlib import Path
+
+
+def run_subprocess(cmd: list[str], src: str = "."):
+    process = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        universal_newlines=True,
+        env=os.environ,
+        cwd=Path(src),
+    )
+
+    # Parse stdout and stderr
+    if process.stdout:
+        for line in process.stdout:
+            print(line, end="")
+    if process.stderr:
+        for line in process.stderr:
+            print(line, end="")
+
+    # Wait for process to complete
+    process.wait()
+
+    return process.returncode
+
+
+# Function to build Docker image
+def build_image(
+    image: str,
+    tag: str,
+    source: str,
+    destination: str,
+    user_id: int,
+    group_id: int,
+    group_name: str,
+    dry_run: bool = False,
+):
+    # Construct path to Dockerfile
+    dockerfile = Path(source) / "Dockerfiles" / image
+    if not dockerfile.exists():
+        raise FileNotFoundError(
+            f"Unable to find Dockerfile for {image} at {str(dockerfile)!r}"
+        )
+
+    # Construct tag
+    image_path = f"{destination}/{image}"
+    if tag:
+        image_path = f"{image_path}:{tag}"
+
+    # Construct bash command to build image
+    build_cmd = [
+        "podman build",
+        f"--build-arg=userid={user_id}",
+        f"--build-arg=groupid={group_id}",
+        f"--build-arg=groupname={group_name}",
+        "--no-cache",
+        f"-f {str(dockerfile)}",
+        f"-t {image_path}",
+        f"{source}",
+    ]
+    bash_cmd = ["bash", "-c", " ".join(build_cmd)]
+
+    if not dry_run:
+        print()
+        # Run subprocess command to build image
+        result = run_subprocess(bash_cmd, source)
+
+        # Check for errors
+        if result != 0:
+            raise RuntimeError(f"Build command failed with exit code {result}")
+
+    if dry_run:
+        print()
+        print(f"Will build image {image!r}")
+        print(f"Will use Dockerfile from {str(dockerfile)!r}")
+        print(
+            f"Will build image with UID {user_id}, GID {group_id}, and group name {group_name}"
+        )
+        print(f"Will build image with tag {image_path}")
+        print("Will run the following bash command:")
+        print(bash_cmd)
+
+    return image_path
+
+
+def tag_image(
+    image_path: str,
+    tags: list[str],
+    dry_run: bool = False,
+):
+    # Construct list of tags to create
+    base_path = image_path.split(":")[0]
+    new_tags = [f"{base_path}:{tag}" for tag in tags]
+
+    # Construct bash command to add all additional tags
+    tag_cmd = [
+        f"for IMAGE in {' '.join(new_tags)};",
+        f"do podman tag {image_path} $IMAGE;",
+        "done",
+    ]
+    bash_cmd = ["bash", "-c", " ".join(tag_cmd)]
+    if not dry_run:
+        print()
+        # Run subprocess command to tag image
+        result = run_subprocess(bash_cmd)
+
+        # Check for errors
+        if result != 0:
+            raise RuntimeError(f"Tag command failed with exit code {result}")
+
+    if dry_run:
+        print()
+        print("Will run the following bash command:")
+        print(bash_cmd)
+        for tag in new_tags:
+            print(f"Will create new tag {tag}")
+
+    return new_tags
+
+
+def push_images(
+    images: list[str],
+    dry_run: bool = False,
+):
+    # Construct bash command to push images
+    push_cmd = [f"for IMAGE in {' '.join(images)};", "do podman push $IMAGE;", "done"]
+    bash_cmd = ["bash", "-c", " ".join(push_cmd)]
+    if not dry_run:
+        print()
+        # Run subprocess command to push image
+        result = run_subprocess(bash_cmd)
+
+        # Check for errors
+        if result != 0:
+            raise RuntimeError(f"Push command failed with exit code {result}")
+
+    if dry_run:
+        print()
+        print("Will run the following bash command:")
+        print(bash_cmd)
+        for image in images:
+            print(f"Will push image {image}")
+
+    return True
+
+
+def cleanup(dry_run: bool = False):
+    # Construct bash command to push images
+    cleanup_cmd = [
+        "podman image prune -f",
+    ]
+    bash_cmd = ["bash", "-c", " ".join(cleanup_cmd)]
+    if not dry_run:
+        print()
+        # Run subprocess command to clean up Podman repo
+        result = run_subprocess(bash_cmd)
+
+        # Check for errors
+        if result != 0:
+            raise RuntimeError(f"Cleanup command failed with exit code {result}")
+
+    if dry_run:
+        print()
+        print("Will run the following bash command:")
+        print(bash_cmd)
+
+    return True
+
+
+def run():
+
+    parser = ArgumentParser(
+        description=(
+            "Uses Podman to build, tag, and push the specified images either locally "
+            "or to a remote repository"
+        )
+    )
+
+    parser.add_argument(
+        "images",
+        nargs="+",
+        help=("Space-separated list of Murfey Dockerfiles that you want to build."),
+    )
+
+    parser.add_argument(
+        "--tags",
+        "-t",
+        nargs="*",
+        default=["latest"],
+        help=("Space-separated list of tags to apply to the built images"),
+    )
+
+    parser.add_argument(
+        "--source",
+        "-s",
+        default=".",
+        help=("Directory path to the Murfey repository"),
+    )
+
+    parser.add_argument(
+        "--destination",
+        "-d",
+        default="localhost",
+        help=("The URL of the repo to push the built images to"),
+    )
+
+    parser.add_argument(
+        "--user-id",
+        default=os.getuid(),
+        help=("The user ID to install in the images"),
+    )
+
+    parser.add_argument(
+        "--group-id",
+        default=os.getgid(),
+        help=("The group ID to install in the images"),
+    )
+
+    parser.add_argument(
+        "--group-name",
+        default=(
+            grp.getgrgid(os.getgid()).gr_name if hasattr(grp, "getgrgid") else "nogroup"
+        ),
+        help=("The group name to install in the images"),
+    )
+
+    parser.add_argument(
+        "--dry-run",
+        default=False,
+        action="store_true",
+        help=(
+            "When specified, prints out what the command would have done for each "
+            "stage of the process"
+        ),
+    )
+
+    args = parser.parse_args()
+
+    # Validate the paths to the images
+    for image in args.images:
+        if not (Path(args.source) / "Dockerfiles" / str(image)).exists():
+            raise FileNotFoundError(
+                "No Dockerfile found in "
+                f"source repository {str(Path(args.source).resolve())!r} for"
+                f"image {str(image)!r}"
+            )
+
+    # Build image
+    images = []
+    for image in args.images:
+        image_path = build_image(
+            image=image,
+            tag=args.tags[0],
+            source=args.source,
+            destination=(
+                str(args.destination).rstrip("/")
+                if str(args.destination).endswith("/")
+                else str(args.destination)
+            ),
+            user_id=args.user_id,
+            group_id=args.group_id,
+            group_name=args.group_name,
+            dry_run=args.dry_run,
+        )
+        images.append(image_path)
+
+        # Create additional tags (if any) for each built image
+        if len(args.tags) > 1:
+            new_tags = tag_image(
+                image_path=image_path,
+                tags=args.tags[1:],
+                dry_run=args.dry_run,
+            )
+            images.extend(new_tags)
+
+    # Push all built images to specified repo
+    push_images(images, dry_run=args.dry_run)
+
+    # Perform final cleanup
+    cleanup(dry_run=args.dry_run)
+
+    # Notify that job is completed
+    print()
+    print("Done")
+
+
+# Allow it to be run directly from the file
+if __name__ == "__main__":
+    run()

--- a/src/murfey/cli/build_images.py
+++ b/src/murfey/cli/build_images.py
@@ -39,7 +39,6 @@ def run_subprocess(cmd: list[str], src: str = "."):
     return process.returncode
 
 
-# Function to build Docker image
 def build_image(
     image: str,
     tag: str,
@@ -116,7 +115,7 @@ def tag_image(
     bash_cmd = ["bash", "-c", " ".join(tag_cmd)]
     if not dry_run:
         print()
-        # Run subprocess command to tag image
+        # Run subprocess command to tag images
         result = run_subprocess(bash_cmd)
 
         # Check for errors
@@ -137,12 +136,12 @@ def push_images(
     images: list[str],
     dry_run: bool = False,
 ):
-    # Construct bash command to push images
+    # Construct bash command to push images to the repo
     push_cmd = [f"for IMAGE in {' '.join(images)};", "do podman push $IMAGE;", "done"]
     bash_cmd = ["bash", "-c", " ".join(push_cmd)]
     if not dry_run:
         print()
-        # Run subprocess command to push image
+        # Run subprocess command
         result = run_subprocess(bash_cmd)
 
         # Check for errors
@@ -160,14 +159,14 @@ def push_images(
 
 
 def cleanup(dry_run: bool = False):
-    # Construct bash command to push images
+    # Construct bash command to clean up Podman repo
     cleanup_cmd = [
         "podman image prune -f",
     ]
     bash_cmd = ["bash", "-c", " ".join(cleanup_cmd)]
     if not dry_run:
         print()
-        # Run subprocess command to clean up Podman repo
+        # Run subprocess command
         result = run_subprocess(bash_cmd)
 
         # Check for errors

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -72,7 +72,7 @@ def test_build_images(mock_subprocess, mock_exists, build_params):
     )
 
     # Check that the image path generated is correct
-    assert built_image == f"{dst}/{images[0]:{tags[0]}}"
+    assert built_image == f"{dst}/{images[0]}:{tags[0]}"
 
 
 test_run_params_matrix: tuple[

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -55,7 +55,7 @@ def test_run(
     # Set up the command based on what these values are
     build_cmd = [
         "murfey.build_images",
-        " ".join(images),
+        *images,
     ]
 
     # Iterate through flags and add them according to the command
@@ -87,16 +87,16 @@ def test_run(
     mock_subprocess.return_value = 0
 
     # Mock 'build_image' return values
-    image_paths = [
+    built_images = [
         f"{dst if dst else def_dst}/{image[0]}:{tags[0] if tags else def_tags[0]}"
         for image in images
     ]
-    mock_build.side_effect = image_paths
+    mock_build.side_effect = built_images
 
     # Mock all the return values when tagging the images
     all_tags = [
         f"{image.split(':')[0]}:{tag}"
-        for image in image_paths
+        for image in built_images
         for tag in (tags if tags else def_tags)
     ]
     mock_tag.side_effect = all_tags

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -1,0 +1,96 @@
+import grp
+import os
+import sys
+from unittest.mock import call, patch
+
+import pytest
+
+from murfey.cli.build_images import run
+
+test_run_params_matrix: tuple[
+    tuple[list[str], list[str], str, str, str, str, str, bool]
+] = (
+    # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
+    # Default settings
+    ([f"test_image_{n}" for n in range(3)], [], "", "", "", "", "", False),
+)
+
+
+@pytest.mark.parametrize("build_params", test_run_params_matrix)
+@patch("murfey.cli.build_images.cleanup")
+@patch("murfey.cli.build_images.push_images")
+@patch("murfey.cli.build_images.tag_image")
+@patch("murfey.cli.build_images.build_image")
+def test_run(
+    mock_build,
+    mock_tag,
+    mock_push,
+    mock_clean,
+    build_params: tuple[list[str], list[str], str, str, str, str, str, bool],
+):
+    """
+    Tests that the function is run with the expected arguments for a given
+    combination of flags.
+    """
+
+    # Unpack build params
+    images, tags, src, dst, uid, gid, gname, dry_run = build_params
+
+    # Set defaults of the various flags
+    def_tags = ["latest"]
+    def_src = "."
+    def_dst = "localhost"
+    def_uid = os.getuid()
+    def_gid = os.getgid()
+    def_gname = (
+        grp.getgrgid(os.getgid()).gr_name if hasattr(grp, "getgrgid") else "nogroup"
+    )
+    def_dry_run = False
+
+    # Set up the command based on what these values are
+    build_cmd = [
+        "murfey.build_images",
+        " ".join(images),
+    ]
+
+    # Iterate through flags and add them according to the command
+    flags = (
+        # 'images' already include by default
+        ("--tags", tags),
+        ("--source", src),
+        ("--destination", dst),
+        ("--user-id", uid),
+        ("--group-id", gid),
+        ("--group-name", gname),
+        ("--dry-run", dry_run),
+    )
+    for flag, value in flags:
+        if isinstance(value, list) and value:
+            build_cmd.extend([flag, *value])
+        if isinstance(value, str) and value:
+            build_cmd.extend([flag, value])
+        if isinstance(value, bool) and value:
+            build_cmd.append(flag)
+
+    # Assign it to the CLI to pass to the function
+    sys.argv = build_cmd
+
+    # Run the function with the command
+    run()
+
+    # Check that the functions were called with the correct flags
+    assert mock_build.call_count == len(images)
+    expected_calls = (
+        call(
+            image=image,
+            tag=tags[0] if tags else def_tags[0],
+            source=src if src else def_src,
+            destination=dst if dst else def_dst,
+            user_id=uid if uid else def_uid,
+            group_id=gid if gid else def_gid,
+            groupd_name=gname if gname else def_gname,
+            dry_run=dry_run if dry_run else def_dry_run,
+        )
+        for image in images
+    )
+    mock_build.assert_has_calls(expected_calls, any_order=True)

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -1,6 +1,7 @@
 import grp
 import os
 import sys
+from pathlib import Path
 from unittest.mock import call, patch
 
 import pytest
@@ -12,7 +13,7 @@ test_run_params_matrix: tuple[
 ] = (
     # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
     # Default settings
-    ([f"test_image_{n}" for n in range(1)], [], "", "", "", "", "", False),
+    ([f"test_image_{n}" for n in range(3)], [], "", "", "", "", "", False),
 )
 
 
@@ -82,6 +83,11 @@ def test_run(
         f"{dst if dst else def_dst}/{image[0]}:{tags[0] if tags else def_tags[0]}"
         for image in images
     ]
+
+    # Create Dockerfiles at the location it expects
+    for image in images:
+        dockerfile = Path(src if src else def_src) / "Dockerfiles" / image
+        dockerfile.touch(exist_ok=True)
 
     # Run the function with the command
     run()

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -98,7 +98,7 @@ tag_image_params_matrix: tuple[tuple[list[str], list[str], str, bool], ...] = (
 def test_tag_image(mock_subprocess, tag_params):
 
     # Unpack build params
-    images, tags, src, dst, uid, gid, gname, dry_run = tag_params
+    images, tags, dst, dry_run = tag_params
 
     # Check that the image path generated is correct
     built_image = f"{dst}/{images[0]}:{tags[0]}"
@@ -147,7 +147,7 @@ test_run_params_matrix: tuple[
 )
 
 
-@pytest.mark.parametrize("build_params", test_run_params_matrix)
+@pytest.mark.parametrize("run_params", test_run_params_matrix)
 @patch("murfey.cli.build_images.Path.exists")
 @patch("murfey.cli.build_images.run_subprocess")
 @patch("murfey.cli.build_images.cleanup")
@@ -161,7 +161,7 @@ def test_run(
     mock_clean,
     mock_subprocess,
     mock_exists,
-    build_params: tuple[list[str], list[str], str, str, str, str, str, bool],
+    run_params: tuple[list[str], list[str], str, str, str, str, str, bool],
 ):
     """
     Tests that the function is run with the expected arguments for a given
@@ -169,7 +169,7 @@ def test_run(
     """
 
     # Unpack build params
-    images, tags, src, dst, uid, gid, gname, dry_run = build_params
+    images, tags, src, dst, uid, gid, gname, dry_run = run_params
 
     # Set up the command based on what these values are
     build_cmd = [

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -11,7 +11,7 @@ images = [f"test_image_{n}" for n in range(3)]
 
 # Set defaults of the various flags
 def_tags = ["latest"]
-def_src = "/home/runner/work/python-murfey/python-murfey"
+def_src = "."
 def_dst = "localhost"
 def_uid = os.getuid()
 def_gid = os.getgid()

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -5,7 +5,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from murfey.cli.build_images import build_image, push_images, run, tag_image
+from murfey.cli.build_images import build_image, cleanup, push_images, run, tag_image
 
 images = [f"test_image_{n}" for n in range(3)]
 
@@ -76,7 +76,7 @@ def test_build_image(mock_subprocess, mock_exists, build_params):
 
 
 tag_image_params_matrix: tuple[tuple[list[str], list[str], str, bool], ...] = (
-    # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
+    # Images | Tags | Destination | Dry Run
     # Populated flags
     (
         images,
@@ -118,7 +118,7 @@ def test_tag_image(mock_subprocess, tag_params):
 
 
 push_image_params_matrix: tuple[tuple[list[str], list[str], str, bool], ...] = (
-    # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
+    # Images | Tags | Destination | Dry Run
     # Populated flags
     (
         images,
@@ -156,6 +156,27 @@ def test_push_images(
         images=images_to_push,
         dry_run=dry_run,
     )
+    assert result
+
+
+test_cleanup_params_matrix: tuple[tuple[bool], ...] = ((True,), (False,))
+
+
+@pytest.mark.parametrize("cleanup_params", test_cleanup_params_matrix)
+@patch("murfey.cli.build_images.run_subprocess")
+def test_cleanup(
+    mock_subprocess,
+    cleanup_params,
+):
+
+    # Unpack test params
+    (dry_run,) = cleanup_params
+
+    # Mock the subprocess return value
+    mock_subprocess.return_value = 0
+
+    # Run the function
+    result = cleanup(dry_run)
     assert result
 
 

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -41,7 +41,7 @@ def test_run(
 
     # Set defaults of the various flags
     def_tags = ["latest"]
-    def_src = "."
+    def_src = "/home/runner/work/python-murfey/python-murfey"
     def_dst = "localhost"
     def_uid = os.getuid()
     def_gid = os.getgid()

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -117,36 +117,6 @@ def test_tag_image(mock_subprocess, tag_params):
     assert image_tags == [f"{built_image.split(':')[0]}:{tag}" for tag in tags[1:]]
 
 
-test_run_params_matrix: tuple[
-    tuple[list[str], list[str], str, str, str, str, str, bool], ...
-] = (
-    # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
-    # Default settings
-    (images, [], "", "", "", "", "", False),
-    # Populated flags
-    (
-        images,
-        ["latest", "dev", "1.1.1"],
-        "",
-        "docker.io",
-        "12345",
-        "34567",
-        "my-group",
-        False,
-    ),
-    (
-        images,
-        ["latest", "dev", "1.1.1"],
-        "",
-        "docker.io",
-        "12345",
-        "34567",
-        "my-group",
-        True,
-    ),
-)
-
-
 push_image_params_matrix: tuple[tuple[list[str], list[str], str, bool], ...] = (
     # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
     # Populated flags
@@ -179,7 +149,7 @@ def test_push_images(
     images_to_push = [f"{dst}/{image}:{tag}" for image in images for tag in tags]
 
     # Mock the subprocess return value
-    mock_subprocess.return_value = True
+    mock_subprocess.return_value = 0
 
     # Run the function
     result = push_images(
@@ -189,8 +159,39 @@ def test_push_images(
     assert result
 
 
+test_run_params_matrix: tuple[
+    tuple[list[str], list[str], str, str, str, str, str, bool], ...
+] = (
+    # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
+    # Default settings
+    (images, [], "", "", "", "", "", False),
+    # Populated flags
+    (
+        images,
+        ["latest", "dev", "1.1.1"],
+        "",
+        "docker.io",
+        "12345",
+        "34567",
+        "my-group",
+        False,
+    ),
+    (
+        images,
+        ["latest", "dev", "1.1.1"],
+        "",
+        "docker.io",
+        "12345",
+        "34567",
+        "my-group",
+        True,
+    ),
+)
+
+
 @pytest.mark.parametrize("run_params", test_run_params_matrix)
 @patch("murfey.cli.build_images.Path.exists")
+@patch("murfey.cli.build_images.run_subprocess")
 @patch("murfey.cli.build_images.cleanup")
 @patch("murfey.cli.build_images.push_images")
 @patch("murfey.cli.build_images.tag_image")

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -92,7 +92,7 @@ def test_run(
     )
     for flag, value in flags:
         if isinstance(value, list) and value:
-            build_cmd.extend([flag, " ".join(value)])
+            build_cmd.extend([flag, *value])
         if isinstance(value, str) and value:
             build_cmd.extend([flag, value])
         if isinstance(value, bool) and value:
@@ -118,7 +118,7 @@ def test_run(
         built_images.append(built_image)
         images_to_push.append(built_image)
         for tag in (tags if tags else def_tags)[1:]:
-            new_tag = f"{image.split(':')[0]}:{tag}"
+            new_tag = f"{built_image.split(':')[0]}:{tag}"
             other_tags.append(new_tag)
             images_to_push.append(new_tag)
 

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -120,7 +120,7 @@ def test_run(
             destination=dst if dst else def_dst,
             user_id=uid if uid else def_uid,
             group_id=gid if gid else def_gid,
-            groupd_name=gname if gname else def_gname,
+            group_name=gname if gname else def_gname,
             dry_run=dry_run if dry_run else def_dry_run,
         )
         for image in images

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -12,11 +12,12 @@ test_run_params_matrix: tuple[
 ] = (
     # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
     # Default settings
-    ([f"test_image_{n}" for n in range(3)], [], "", "", "", "", "", False),
+    ([f"test_image_{n}" for n in range(1)], [], "", "", "", "", "", False),
 )
 
 
 @pytest.mark.parametrize("build_params", test_run_params_matrix)
+@patch("murfey.cli.build_images.run_subprocess")
 @patch("murfey.cli.build_images.cleanup")
 @patch("murfey.cli.build_images.push_images")
 @patch("murfey.cli.build_images.tag_image")
@@ -26,6 +27,7 @@ def test_run(
     mock_tag,
     mock_push,
     mock_clean,
+    mock_subprocess,
     build_params: tuple[list[str], list[str], str, str, str, str, str, bool],
 ):
     """
@@ -74,6 +76,12 @@ def test_run(
 
     # Assign it to the CLI to pass to the function
     sys.argv = build_cmd
+
+    # Mock 'build_image' return value
+    mock_build.side_effect = [
+        f"{dst if dst else def_dst}/{image[0]}:{tags[0] if tags else def_tags[0]}"
+        for image in images
+    ]
 
     # Run the function with the command
     run()

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -25,12 +25,10 @@ test_run_params_matrix: tuple[
     # Images | Tags | Source | Destination | User ID | Group ID | Group Name | Dry Run
     # Default settings
     (images, [], "", "", "", "", "", False),
+    # Populated flags
     (
         images,
-        [
-            "latest",
-            "dev",
-        ],
+        ["latest", "dev", "1.1.1"],
         "",
         "docker.io",
         "12345",
@@ -40,10 +38,7 @@ test_run_params_matrix: tuple[
     ),
     (
         images,
-        [
-            "latest",
-            "dev",
-        ],
+        ["latest", "dev", "1.1.1"],
         "",
         "docker.io",
         "12345",
@@ -157,11 +152,11 @@ def test_run(
 
     # Check that 'tag_image' was called with the correct arguments
     if other_tags:
-        assert mock_tag.call_count == len(images) * len(other_tags)
+        assert mock_tag.call_count == len(other_tags)
         expected_tag_calls = (
             call(
                 image_path=image,
-                tags=other_tags,
+                tags=tags[1:],
                 dry_run=dry_run if dry_run else def_dry_run,
             )
             for image in built_images

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -154,7 +154,7 @@ def test_run(
 
     # Check that 'tag_image' was called with the correct arguments
     if tags[1:]:
-        assert mock_tag.call_count == len(tags[1:])
+        assert mock_tag.call_count == len(built_images)
         expected_tag_calls = (
             call(
                 image_path=image,

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -153,8 +153,8 @@ def test_run(
     mock_build.assert_has_calls(expected_build_calls, any_order=True)
 
     # Check that 'tag_image' was called with the correct arguments
-    if other_tags:
-        assert mock_tag.call_count == len(built_images)
+    if tags[1:]:
+        assert mock_tag.call_count == len(tags[1:])
         expected_tag_calls = (
             call(
                 image_path=image,

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -109,7 +109,7 @@ def test_run(
 
     # Construct images that will be generated at the different stages of the process
     built_images: list[str] = []
-    other_tags: list[str] = []
+    other_tags: list[list[str]] = []
     images_to_push: list[str] = []
     for image in images:
         built_image = (
@@ -117,10 +117,12 @@ def test_run(
         )
         built_images.append(built_image)
         images_to_push.append(built_image)
-        for tag in (tags if tags else def_tags)[1:]:
-            new_tag = f"{built_image.split(':')[0]}:{tag}"
-            other_tags.append(new_tag)
-            images_to_push.append(new_tag)
+        new_tags = [
+            f"{built_image.split(':')[0]}:{tag}"
+            for tag in (tags if tags else def_tags)[1:]
+        ]
+        other_tags.append(new_tags)
+        images_to_push.extend(new_tags)
 
     # Mock the return values of 'build_image' and 'tag_iamge'
     mock_build.side_effect = built_images

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -118,7 +118,7 @@ def test_run(
     images_to_push: list[str] = []
     for image in images:
         built_image = (
-            f"{dst if dst else def_dst}/{image[0]}:{tags[0] if tags else def_tags[0]}"
+            f"{dst if dst else def_dst}/{image}:{tags[0] if tags else def_tags[0]}"
         )
         built_images.append(built_image)
         images_to_push.append(built_image)
@@ -170,17 +170,11 @@ def test_run(
 
     # Check that 'push_images' was called with the correct arguments
     mock_push.assert_called_once_with(
-        call(
-            images=images_to_push,
-            dry_run=dry_run if dry_run else def_dry_run,
-        ),
-        any_order=True,
+        images=images_to_push,
+        dry_run=dry_run if dry_run else def_dry_run,
     )
 
     # Check that 'cleanup' was called correctly
     mock_clean.assert_called_once_with(
-        call(
-            dry_run=dry_run if dry_run else def_dry_run,
-        ),
-        any_order=True,
+        dry_run=dry_run if dry_run else def_dry_run,
     )

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -80,14 +80,17 @@ def test_run(
     # Assign it to the CLI to pass to the function
     sys.argv = build_cmd
 
-    # Mock 'build_image' return value
+    # Mock the check for the existence of the Dockerfiles
+    mock_exists.return_value = True
+
+    # Mock the exit code of the subprocesses being run
+    mock_subprocess.return_value = 0
+
+    # Mock 'build_image' return values
     mock_build.side_effect = [
         f"{dst if dst else def_dst}/{image[0]}:{tags[0] if tags else def_tags[0]}"
         for image in images
     ]
-
-    # Mock the check for the existence of the Dockerfiles
-    mock_exists.return_value = True
 
     # Run the function with the command
     run()

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -87,10 +87,25 @@ def test_run(
     mock_subprocess.return_value = 0
 
     # Mock 'build_image' return values
-    mock_build.side_effect = [
+    image_paths = [
         f"{dst if dst else def_dst}/{image[0]}:{tags[0] if tags else def_tags[0]}"
         for image in images
     ]
+    mock_build.side_effect = image_paths
+
+    # Mock all the return values when tagging the images
+    all_tags = [
+        f"{image.split(':')[0]}:{tag}"
+        for image in image_paths
+        for tag in (tags if tags else def_tags)
+    ]
+    mock_tag.side_effect = all_tags
+
+    # Mock the push function
+    mock_push.return_value = True
+
+    # Mock the cleanup function
+    mock_clean.return_value = True
 
     # Run the function with the command
     run()

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -92,7 +92,7 @@ def test_run(
     )
     for flag, value in flags:
         if isinstance(value, list) and value:
-            build_cmd.extend([flag, *value])
+            build_cmd.extend([flag, " ".join(value)])
         if isinstance(value, str) and value:
             build_cmd.extend([flag, value])
         if isinstance(value, bool) and value:

--- a/tests/cli/test_build_images.py
+++ b/tests/cli/test_build_images.py
@@ -152,7 +152,7 @@ def test_run(
 
     # Check that 'tag_image' was called with the correct arguments
     if other_tags:
-        assert mock_tag.call_count == len(other_tags)
+        assert mock_tag.call_count == len(built_images)
         expected_tag_calls = (
             call(
                 image_path=image,


### PR DESCRIPTION
I ended up making this CLI due to having to repeatedly build and push Murfey images as part of the testing process. 

This is designed to work with a bash shell that has been configured with Podman, and can be pointed to either remote or local Docker image repositories.