### PR TITLE
Save parameters from instrument server and reuse them from the murfey database

### DIFF
--- a/src/murfey/cli/spa_ispyb_messages.py
+++ b/src/murfey/cli/spa_ispyb_messages.py
@@ -223,12 +223,12 @@ def run():
     metadata["image_size_y"] = str(int(metadata["image_size_y"]) * binning_factor)
     metadata["motion_corr_binning"] = 1 if binning_factor_xml == 2 else 2
     metadata["gain_ref"] = (
-        f"data/{datetime.now().year}/{args.visit}/processing/gain.mrc"
+        f"{datetime.now().year}/{args.visit}/processing/gain.mrc"
         if args.gain_ref is None
         else args.gain_ref
     )
     metadata["gain_ref_superres"] = (
-        f"data/{datetime.now().year}/{args.visit}/processing/gain_superres.mrc"
+        f"{datetime.now().year}/{args.visit}/processing/gain_superres.mrc"
         if args.gain_ref_superres is None
         else args.gain_ref_superres
     )

--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -298,14 +298,14 @@ class SPAModularContext(Context):
                 if environment
                 and environment.data_collection_parameters.get("gain_ref")
                 not in (None, "None")
-                else f"data/{datetime.now().year}/{environment.visit}/processing/gain.mrc"
+                else f"{datetime.now().year}/{environment.visit}/processing/gain.mrc"
             )
             metadata["gain_ref_superres"] = (
                 environment.data_collection_parameters.get("gain_ref_superres")
                 if environment
                 and environment.data_collection_parameters.get("gain_ref_superres")
                 not in (None, "None")
-                else f"data/{datetime.now().year}/{environment.visit}/processing/gain_superres.mrc"
+                else f"{datetime.now().year}/{environment.visit}/processing/gain_superres.mrc"
             )
         else:
             metadata["gain_ref"] = None

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -618,7 +618,7 @@ class TomographyContext(Context):
                     environment.data_collection_parameters.get("gain_ref")
                     if environment.data_collection_parameters.get("gain_ref")
                     not in (None, "None")
-                    else f"data/{datetime.now().year}/{environment.visit}/processing/gain.mrc"
+                    else f"{datetime.now().year}/{environment.visit}/processing/gain.mrc"
                 )
             else:
                 mdoc_metadata["gain_ref"] = None

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -220,12 +220,12 @@ def restart_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource):
 
 
 class ProcessingParameters(BaseModel):
+    gain_ref: str
     dose_per_frame: Optional[float] = None
     extract_downscale: bool = True
     particle_diameter: Optional[float] = None
     symmetry: str = "C1"
     eer_fractionation: int = 20
-    gain_ref: Optional[str] = None
 
 
 class ProcessingParameterBlock(BaseModel):

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -225,6 +225,7 @@ class ProcessingParameters(BaseModel):
     particle_diameter: Optional[float] = None
     symmetry: str = "C1"
     eer_fractionation: int = 20
+    gain_ref: Optional[str] = None
 
 
 class ProcessingParameterBlock(BaseModel):
@@ -238,7 +239,8 @@ def register_processing_parameters(
 ):
     data_collection_parameters[proc_param_block.label] = {}
     for k, v in proc_param_block.params.dict().items():
-        data_collection_parameters[proc_param_block.label][k] = v
+        if v is not None:
+            data_collection_parameters[proc_param_block.label][k] = v
     return {"success": True}
 
 

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -2490,7 +2490,7 @@ def feedback_callback(header: dict, message: dict) -> None:
                     ),
                     voltage=message["voltage"],
                     motion_corr_binning=message["motion_corr_binning"],
-                    eer_grouping=message["eer_fractionation"],
+                    eer_fractionation_file=message["eer_fractionation_file"],
                     symmetry=message["symmetry"],
                     particle_diameter=message["particle_diameter"],
                     downscale=message["downscale"],

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -478,6 +478,19 @@ def get_spa_proc_param_details(
 def register_spa_proc_params(
     session_id: MurfeySessionID, proc_params: ProcessingParametersSPA, db=murfey_db
 ):
+    session_processing_parameters = db.exec(
+        select(SessionProcessingParameters).where(
+            SessionProcessingParameters.session_id == session_id
+        )
+    ).all()
+    if session_processing_parameters:
+        proc_params.gain_ref = session_processing_parameters[0].gain_ref
+        proc_params.dose_per_frame = session_processing_parameters[0].dose_per_frame
+        proc_params.eer_fractionation_file = session_processing_parameters[
+            0
+        ].eer_fractionation_file
+        proc_params.symmetry = session_processing_parameters[0].symmetry
+
     zocalo_message = {
         "register": "spa_processing_parameters",
         **dict(proc_params),
@@ -606,6 +619,18 @@ def post_foil_hole(
 def register_tomo_preproc_params(
     session_id: MurfeySessionID, proc_params: PreprocessingParametersTomo, db=murfey_db
 ):
+    session_processing_parameters = db.exec(
+        select(SessionProcessingParameters).where(
+            SessionProcessingParameters.session_id == session_id
+        )
+    ).all()
+    if session_processing_parameters:
+        proc_params.gain_ref = session_processing_parameters[0].gain_ref
+        proc_params.dose_per_frame = session_processing_parameters[0].dose_per_frame
+        proc_params.eer_fractionation_file = session_processing_parameters[
+            0
+        ].eer_fractionation_file
+
     zocalo_message = {
         "register": "tomography_processing_parameters",
         **dict(proc_params),
@@ -1247,7 +1272,6 @@ async def request_tomography_preprocessing(
             proc_file.eer_fractionation_file = processing_job_parameters[
                 0
             ].eer_fractionation_file
-            proc_file.mc_binning = processing_job_parameters[0].motion_corr_binning
 
         zocalo_message: dict = {
             "recipes": [recipe_name],

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -65,6 +65,7 @@ from murfey.util.db import (
     ProcessingJob,
     RsyncInstance,
     Session,
+    SessionProcessingParameters,
     SPAFeedbackParameters,
     SPARelionParameters,
     Tilt,
@@ -1142,7 +1143,11 @@ async def request_spa_preprocessing(
                 "picker_uuid": murfey_ids[1],
                 "session_id": session_id,
                 "particle_diameter": proc_params["particle_diameter"] or 0,
-                "fm_int_file": proc_file.eer_fractionation_file,
+                "fm_int_file": (
+                    proc_params["eer_fractionation_file"]
+                    if proc_params["eer_fractionation_file"]
+                    else proc_file.eer_fractionation_file
+                ),
                 "do_icebreaker_jobs": default_spa_parameters.do_icebreaker_jobs,
                 "cryolo_model_weights": str(
                     _cryolo_model_path(visit_name, instrument_name)
@@ -1229,6 +1234,21 @@ async def request_tomography_preprocessing(
         murfey_ids = _murfey_id(appid, db, number=1, close=False)
         if not mrc_out.parent.exists():
             mrc_out.parent.mkdir(parents=True, exist_ok=True)
+
+        processing_job_parameters = db.exec(
+            select(TomographyProcessingParameters).where(
+                TomographyProcessingParameters.processing_job_id
+                == data_collection[2].id
+            )
+        ).all()
+        if processing_job_parameters:
+            proc_file.gain_ref = processing_job_parameters[0].gain_ref
+            proc_file.dose_per_frame = processing_job_parameters[0].dose_per_frame
+            proc_file.eer_fractionation_file = processing_job_parameters[
+                0
+            ].eer_fractionation_file
+            proc_file.mc_binning = processing_job_parameters[0].motion_corr_binning
+
         zocalo_message: dict = {
             "recipes": [recipe_name],
             "parameters": {
@@ -1514,6 +1534,24 @@ def register_proc(
         },
     }
 
+    session_processing_parameters = db.exec(
+        select(SessionProcessingParameters).where(
+            SessionProcessingParameters.session_id == session_id
+        )
+    ).all()
+
+    if session_processing_parameters:
+        proc_params["job_parameters"].update(
+            {
+                "gain_ref": session_processing_parameters[0].gain_ref,
+                "dose_per_frame": session_processing_parameters[0].dose_per_frame,
+                "eer_fractionation_file": session_processing_parameters[
+                    0
+                ].eer_fractionation_file,
+                "symmetry": session_processing_parameters[0].symmetry,
+            }
+        )
+
     if _transport_object:
         _transport_object.send(
             _transport_object.feedback_queue,
@@ -1654,6 +1692,17 @@ async def write_eer_fractionation_file(
             / machine_config.gain_directory_name
             / secure_filename(fractionation_params.fractionation_file_name)
         )
+
+    session_parameters = db.exec(
+        select(SessionProcessingParameters).where(
+            SessionProcessingParameters.session_id == session_id
+        )
+    ).all()
+    if session_parameters:
+        session_parameters[0].eer_fractionation_file = str(file_path)
+        db.add(session_parameters)
+        db.commit()
+
     if file_path.is_file():
         return {"eer_fractionation_file": str(file_path)}
 

--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -145,6 +145,7 @@ class ProvidedProcessingParameters(BaseModel):
     particle_diameter: Optional[float] = None
     symmetry: str = "C1"
     eer_fractionation: int = 20
+    gain_ref: Optional[str] = None
 
 
 @router.post("/sessions/{session_id}/provided_processing_parameters")
@@ -171,6 +172,7 @@ async def pass_proc_params_to_instrument_server(
                         "particle_diameter": proc_params.particle_diameter,
                         "symmetry": proc_params.symmetry,
                         "eer_fractionation": proc_params.eer_fractionation,
+                        "gain_ref": proc_params.gain_ref,
                     },
                 },
                 headers={

--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -326,6 +326,14 @@ TEM SESSION AND PROCESSING WORKFLOW
 """
 
 
+class SessionProcessingParameters(SQLModel, table=True):  # type: ignore
+    session_id: int = Field(foreign_key="session.id", primary_key=True)
+    gain_ref: str
+    dose_per_frame: float
+    eer_fractionation_file: str = ""
+    symmetry: str = "C1"
+
+
 class TiltSeries(SQLModel, table=True):  # type: ignore
     id: int = Field(primary_key=True)
     tag: str
@@ -641,7 +649,7 @@ class SPARelionParameters(SQLModel, table=True):  # type: ignore
     gain_ref: Optional[str]
     voltage: int
     motion_corr_binning: int
-    eer_grouping: int
+    eer_fractionation_file: str = ""
     symmetry: str
     particle_diameter: Optional[float]
     downscale: bool

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -226,7 +226,7 @@ class ProcessingParametersSPA(BaseModel):
     boxsize: Optional[int]
     downscale: bool
     small_boxsize: Optional[int]
-    eer_fractionation: int
+    eer_fractionation_file: str = ""
     particle_diameter: Optional[float]
     magnification: Optional[int] = None
     total_exposed_dose: Optional[float] = None

--- a/src/murfey/workflows/spa/flush_spa_preprocess.py
+++ b/src/murfey/workflows/spa/flush_spa_preprocess.py
@@ -417,7 +417,11 @@ def flush_spa_preprocess(message: dict, murfey_db: Session, demo: bool = False) 
                 "picker_uuid": murfey_ids[2 * i + 1],
                 "session_id": session_id,
                 "particle_diameter": proc_params.particle_diameter or 0,
-                "fm_int_file": f.eer_fractionation_file,
+                "fm_int_file": (
+                    proc_params.eer_fractionation_file
+                    if proc_params.eer_fractionation_file
+                    else f.eer_fractionation_file
+                ),
                 "do_icebreaker_jobs": default_spa_parameters.do_icebreaker_jobs,
                 "foil_hole_id": foil_hole_id,
             },


### PR DESCRIPTION
Restarting the instrument server causes parameters to be lost, and the gain reference is not set correctly in messages from the instrument server.
This save these into a new table, and uses them in preference to values from the client/instrument