### PR TITLE
Fixed package dependencies for 'instrument-server' key

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,7 @@ developer = [
 ]
 instrument-server = [
     "fastapi[standard]",
-    "python-jose[cryptography]",
-    "uvicorn[standard]",
+    "python-jose",
 ]
 server = [
     "aiohttp",
@@ -73,7 +72,6 @@ server = [
     "sqlalchemy[postgresql]", # Add as explicit dependency
     "sqlmodel",
     "stomp-py<=8.1.0", # 8.1.1 (released 2024-04-06) doesn't work with our project
-    "uvicorn[standard]",
     "zocalo",
 ]
 [project.urls]


### PR DESCRIPTION
Streamlined and fixed dependencies for `instrument-server` key:
* `uvicorn[standard]` is included as part of `fastapi[standard]`
* `PyYAML` is included as part of `uvicorn[standard]`
* `cryptography` is the one that is failing to install on `MSYS2`, but is not needed on client side.