### PR TITLE
Use UUID for websocket connection for logging from the instrument server

### DIFF
--- a/src/murfey/instrument_server/__init__.py
+++ b/src/murfey/instrument_server/__init__.py
@@ -37,7 +37,7 @@ def run():
 
     ws = murfey.client.websocket.WSApp(
         server=read_config()["Murfey"].get("server"),
-        id=0,
+        register_client=False,
     )
 
     handler = CustomHandler(ws.send)


### PR DESCRIPTION
This needs testing but may resolve the websocket ID clashes we've seen