### PR TITLE
Fix binning factor for image size from multigrid controller

### DIFF
--- a/src/murfey/client/instance_environment.py
+++ b/src/murfey/client/instance_environment.py
@@ -49,7 +49,7 @@ class MurfeyInstanceEnvironment(BaseModel):
     visit: str = ""
     processing_only_mode: bool = False
     gain_ref: Optional[Path] = None
-    superres: bool = True
+    superres: bool = False
     murfey_session: Optional[int] = None
     samples: Dict[Path, SampleInfo] = {}
     rsync_url: str = ""


### PR DESCRIPTION
Default InstanceEnvironment superres value to False to account for behaviour of web UI

Possibly we just don't want this at all