### PR TITLE
Allow setup page order to be switched in web UI

### DIFF
--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -241,6 +241,10 @@ def register_processing_parameters(
     for k, v in proc_param_block.params.dict().items():
         if v is not None:
             data_collection_parameters[proc_param_block.label][k] = v
+    if controllers.get(session_id):
+        controllers[session_id].data_collection_parameters.update(
+            data_collection_parameters[proc_param_block.label]
+        )
     return {"success": True}
 
 


### PR DESCRIPTION
Either order for the rsyncer setup and processing parameters should now be acceptable