### PR TITLE
Allow visit completion to run more asynchronously

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ developer = [
     "pytest", # Test code functionality
 ]
 instrument-server = [
+    "aiohttp",
     "fastapi[standard]",
     "python-jose[cryptography]",
     "uvicorn[standard]",

--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -404,6 +404,7 @@ class Analyser(Observer):
                     )
                     self.post_transfer(transferred_file)
             self.queue.task_done()
+        self.notify(final=True)
 
     def _xml_file(self, data_file: Path) -> Path:
         if not self._environment:
@@ -431,6 +432,10 @@ class Analyser(Observer):
             raise RuntimeError("Analyser has already stopped")
         logger.info(f"Analyser thread starting for {self}")
         self.thread.start()
+
+    def request_stop(self):
+        self._stopping = True
+        self._halt_thread = True
 
     def stop(self):
         logger.debug("Analyser thread stop requested")

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -99,6 +99,7 @@ class MultigridController:
 
     def _multigrid_watcher_finalised(self):
         self.multigrid_watcher_active = False
+        self.dormancy_check()
 
     def dormancy_check(self):
         if not self.multigrid_watcher_active:

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -34,6 +34,8 @@ class MultigridController:
     rsync_url: str = ""
     rsync_module: str = "data"
     demo: bool = False
+    dormant: bool = False
+    multigrid_watcher_active: bool = True
     processing_enabled: bool = True
     do_transfer: bool = True
     dummy_dc: bool = False
@@ -94,6 +96,9 @@ class MultigridController:
             server=self.murfey_url,
             register_client=False,
         )
+
+    def _multigrid_watcher_finalised(self):
+        self.multigrid_watcher_active = False
 
     def _start_rsyncer_multigrid(
         self,

--- a/src/murfey/client/watchdir.py
+++ b/src/murfey/client/watchdir.py
@@ -63,6 +63,10 @@ class DirWatcher(murfey.util.Observer):
         log.info(f"DirWatcher thread starting for {self}")
         self.thread.start()
 
+    def request_stop(self):
+        self._stopping = True
+        self._halt_thread = True
+
     def stop(self):
         log.debug("DirWatcher thread stop requested")
         self._stopping = True
@@ -90,6 +94,7 @@ class DirWatcher(murfey.util.Observer):
                 modification_time=modification_time, transfer_all=self._transfer_all
             )
             time.sleep(15)
+        self.notify(final=True)
 
     def scan(self, modification_time: float | None = None, transfer_all: bool = False):
         """

--- a/src/murfey/client/watchdir_multigrid.py
+++ b/src/murfey/client/watchdir_multigrid.py
@@ -114,3 +114,5 @@ class MultigridDirWatcher(murfey.util.Observer):
             if first_loop:
                 first_loop = False
             time.sleep(15)
+
+        self.notify(final=True)

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -179,7 +179,9 @@ def start_multigrid_watcher(
             destination_overrides=watcher_spec.destination_overrides,
         )
     )
-    watchers[session_id].subscribe(controllers[session_id]._multigrid_watcher_finalised)
+    watchers[session_id].subscribe(
+        controllers[session_id]._multigrid_watcher_finalised, final=True
+    )
     watchers[session_id].start()
     return {"success": True}
 
@@ -219,6 +221,7 @@ def finalise_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource)
 
 @router.post("/sessions/{session_id}/finalise_session")
 def finalise_session(session_id: MurfeySessionID):
+    watchers[session_id].request_stop()
     controllers[session_id].finalise()
     return {"success": True}
 

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -147,10 +147,6 @@ def start_multigrid_watcher(
     for sid, controller in controllers.items():
         if controller.dormant:
             del controllers[sid]
-            requests.delete(
-                f"{_get_murfey_url()}/sessions/{sanitise_nonpath(str(sid))}",
-                headers={"Authorization": f"Bearer {tokens[sid]}"},
-            )
     controllers[session_id] = MultigridController(
         [],
         watcher_spec.visit,

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -148,7 +148,7 @@ def start_multigrid_watcher(
         if controller.dormant:
             del controllers[sid]
             requests.delete(
-                f"{_get_murfey_url()}/sessions/{sid}",
+                f"{_get_murfey_url()}/sessions/{sanitise_nonpath(str(sid))}",
                 headers={"Authorization": f"Bearer {tokens[sid]}"},
             )
     controllers[session_id] = MultigridController(

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -176,6 +176,7 @@ def start_multigrid_watcher(
             destination_overrides=watcher_spec.destination_overrides,
         )
     )
+    watchers[session_id].subscribe(controllers[session_id]._multigrid_watcher_finalised)
     watchers[session_id].start()
     return {"success": True}
 

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -144,6 +144,9 @@ def start_multigrid_watcher(
     if controllers.get(session_id) is not None:
         return {"success": True}
     label = watcher_spec.label
+    for sid, controller in controllers.items():
+        if controller.dormant:
+            del controllers[sid]
     controllers[session_id] = MultigridController(
         [],
         watcher_spec.visit,

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -147,6 +147,10 @@ def start_multigrid_watcher(
     for sid, controller in controllers.items():
         if controller.dormant:
             del controllers[sid]
+            requests.delete(
+                f"{_get_murfey_url()}/sessions/{sid}",
+                headers={"Authorization": f"Bearer {tokens[sid]}"},
+            )
     controllers[session_id] = MultigridController(
         [],
         watcher_spec.visit,

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -214,6 +214,12 @@ def finalise_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource)
     return {"success": True}
 
 
+@router.post("/sessions/{session_id}/finalise_session")
+def finalise_session(session_id: MurfeySessionID):
+    controllers[session_id].finalise()
+    return {"success": True}
+
+
 @router.post("/sessions/{session_id}/restart_rsyncer")
 def restart_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource):
     controllers[session_id]._restart_rsyncer(rsyncer_source.source)

--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -21,7 +21,7 @@ from murfey.server.api.auth import (
     validate_token,
 )
 from murfey.server.murfey_db import murfey_db
-from murfey.util import secure_path
+from murfey.util import sanitise_nonpath, secure_path
 from murfey.util.config import get_machine_config
 from murfey.util.db import Session, SessionProcessingParameters
 from murfey.util.models import File, MultigridWatcherSetup
@@ -365,7 +365,7 @@ async def finalise_session(session_id: MurfeySessionID, db=murfey_db):
     if machine_config.instrument_server_url:
         async with aiohttp.ClientSession() as clientsession:
             async with clientsession.post(
-                f"{machine_config.instrument_server_url}/sessions/{session_id}/finalise_session",
+                f"{machine_config.instrument_server_url}/sessions/{sanitise_nonpath(str(session_id))}/finalise_session",
                 headers={
                     "Authorization": f"Bearer {instrument_server_tokens[session_id]['access_token']}"
                 },

--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -21,7 +21,7 @@ from murfey.server.api.auth import (
     validate_token,
 )
 from murfey.server.murfey_db import murfey_db
-from murfey.util import sanitise_nonpath, secure_path
+from murfey.util import secure_path
 from murfey.util.config import get_machine_config
 from murfey.util.db import Session, SessionProcessingParameters
 from murfey.util.models import File, MultigridWatcherSetup
@@ -365,7 +365,7 @@ async def finalise_session(session_id: MurfeySessionID, db=murfey_db):
     if machine_config.instrument_server_url:
         async with aiohttp.ClientSession() as clientsession:
             async with clientsession.post(
-                f"{machine_config.instrument_server_url}/sessions/{sanitise_nonpath(str(session_id))}/finalise_session",
+                f"{machine_config.instrument_server_url}/sessions/{session_id}/finalise_session",
                 headers={
                     "Authorization": f"Bearer {instrument_server_tokens[session_id]['access_token']}"
                 },

--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -353,6 +353,27 @@ async def finalise_rsyncer(
     return data
 
 
+@router.post("/sessions/{session_id}/finalise_session")
+async def finalise_session(session_id: MurfeySessionID, db=murfey_db):
+    data = {}
+    instrument_name = (
+        db.exec(select(Session).where(Session.id == session_id)).one().instrument_name
+    )
+    machine_config = get_machine_config(instrument_name=instrument_name)[
+        instrument_name
+    ]
+    if machine_config.instrument_server_url:
+        async with aiohttp.ClientSession() as clientsession:
+            async with clientsession.post(
+                f"{machine_config.instrument_server_url}/sessions/{session_id}/finalise_session",
+                headers={
+                    "Authorization": f"Bearer {instrument_server_tokens[session_id]['access_token']}"
+                },
+            ) as resp:
+                data = await resp.json()
+    return data
+
+
 @router.post("/sessions/{session_id}/remove_rsyncer")
 async def remove_rsyncer(
     session_id: MurfeySessionID, rsyncer_source: RsyncerSource, db=murfey_db

--- a/src/murfey/util/state.py
+++ b/src/murfey/util/state.py
@@ -69,9 +69,12 @@ class State(Mapping[str, T], Observer):
         self,
         fn: Callable[[str, T | None], Awaitable[None] | None],
         secondary: bool = False,
+        final: bool = False,
     ):
         if secondary:
             self._secondary_listeners.append(fn)
+        elif final:
+            self._final_listeners.append(fn)
         else:
             self._listeners.append(fn)
 


### PR DESCRIPTION
The multigrid controller should now be able to handle most of the process of cleaning up all associated threads. Thread completion requests are performed by setting flags and not explicitly waiting for `join`s. Callbacks are then used to notify of thread completion. (`RSyncer` threads are slightly more complicated because they have to perform file removal after completing.) 

On completion of all associated threads the multigrid controller will mark itself as dormant. When new multigrid controllers are added dormant controllers are checked for and removed along with the associated Murfey session data. This could also possibly be triggered when the controller marks itself as dormant for a quicker cleanup?