### PR TITLE
Adjusted type hint for '_get_session()'

### DIFF
--- a/src/murfey/server/ispyb.py
+++ b/src/murfey/server/ispyb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime
 import logging
-from typing import Callable, List, Literal, Optional
+from typing import Callable, Generator, List, Literal, Optional
 
 import ispyb
 
@@ -535,7 +535,7 @@ class TransportManager:
         return reference
 
 
-def _get_session() -> sqlalchemy.orm.Session:
+def _get_session() -> Generator[Optional[sqlalchemy.orm.Session], None, None]:
     db = Session()
     if db is None:
         yield None


### PR DESCRIPTION
`_get_session()` can return either `None` or a `Generator` object that yields `sqlalchemy.orm.Session` or `None`. Updated the type hint to reflect that.