### PR TITLE
Use a secure websocket scheme if server is https

### DIFF
--- a/src/murfey/client/websocket.py
+++ b/src/murfey/client/websocket.py
@@ -27,7 +27,9 @@ class WSApp:
         websocket.enableTrace(True)
 
         # Parse server URL and get proxy path used, if any
-        url = urllib.parse.urlparse(server)._replace(scheme="ws")
+        url = urllib.parse.urlparse(server)._replace(
+            scheme="wss" if server.startswith("https") else "ws"
+        )
         proxy_path = url.path.rstrip("/")
 
         self._address = url.geturl()


### PR DESCRIPTION
This may resolve the issues we were seeing when proxying the websocket through https