### PR TITLE
Override the tomography processing parameters with ones from web ui

### DIFF
--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -1949,7 +1949,7 @@ def _register_bfactors(message: dict, _db=murfey_db, demo: bool = False):
 
     if message["symmetry"] != relion_params.symmetry:
         # Currently don't do anything with a symmetrised re-run of the refinement
-        logger.info(f"Recieved symmetrised structure of {message['symmetry']}")
+        logger.info(f"Received symmetrised structure of {message['symmetry']}")
         return True
 
     if not feedback_params.hold_refine:

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -1949,7 +1949,9 @@ def _register_bfactors(message: dict, _db=murfey_db, demo: bool = False):
 
     if message["symmetry"] != relion_params.symmetry:
         # Currently don't do anything with a symmetrised re-run of the refinement
-        logger.info(f"Received symmetrised structure of {message['symmetry']}")
+        logger.info(
+            f"Received symmetrised structure of {sanitise(message['symmetry'])}"
+        )
         return True
 
     if not feedback_params.hold_refine:

--- a/src/murfey/server/demo_api.py
+++ b/src/murfey/server/demo_api.py
@@ -73,7 +73,6 @@ from murfey.util.models import (
     GridSquareParameters,
     PostInfo,
     PreprocessingParametersTomo,
-    ProcessFile,
     ProcessingJobParameters,
     ProcessingParametersSPA,
     ProcessingParametersTomo,
@@ -86,6 +85,7 @@ from murfey.util.models import (
     TiltInfo,
     TiltSeriesGroupInfo,
     TiltSeriesInfo,
+    TomoProcessFile,
     Visit,
 )
 from murfey.util.processing_params import default_spa_parameters
@@ -1196,7 +1196,7 @@ def flush_tomography_processing(
 
 @router.post("/visits/{visit_name}/{client_id}/tomography_preprocess")
 async def request_tomography_preprocessing(
-    visit_name: str, client_id: int, proc_file: ProcessFile, db=murfey_db
+    visit_name: str, client_id: int, proc_file: TomoProcessFile, db=murfey_db
 ):
     if not sanitise_path(Path(proc_file.path)).exists():
         log.warning(

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -350,7 +350,7 @@ class CompletedTiltSeries(BaseModel):
 
 
 class PreprocessingParametersTomo(BaseModel):
-    dose_per_frame: float
+    dose_per_frame: Optional[float]
     frame_count: int
     tilt_axis: float
     gain_ref: Optional[str]

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -308,13 +308,13 @@ Models related to the tomographic reconstruction workflow.
 """
 
 
-class ProcessFile(BaseModel):  # Rename to TomoProcessFile
+class TomoProcessFile(BaseModel):
     path: str
     description: str
     tag: str
     image_number: int
     pixel_size: float
-    dose_per_frame: float
+    dose_per_frame: Optional[float]
     frame_count: int
     tilt_axis: Optional[float]
     mc_uuid: Optional[int] = None


### PR DESCRIPTION
Tomography processing did not allow a dose of zero, which happens if the instrument server is reconnected. This ensures that in that case the processing parameters in the `SessionProcessingParameters` table are used.