### PR TITLE
Add information about the analysers into the rsyncer api calls

### DIFF
--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -239,7 +239,7 @@ def restart_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource):
     return {"success": True}
 
 
-class RSyncerInfo(BaseModel):
+class ObserverInfo(BaseModel):
     source: str
     num_files_transferred: int
     num_files_in_queue: int
@@ -248,11 +248,11 @@ class RSyncerInfo(BaseModel):
 
 
 @router.get("/sessions/{session_id}/rsyncer_info")
-def get_rsyncer_info(session_id: MurfeySessionID) -> list[RSyncerInfo]:
+def get_rsyncer_info(session_id: MurfeySessionID) -> list[ObserverInfo]:
     info = []
     for k, v in controllers[session_id].rsync_processes.items():
         info.append(
-            RSyncerInfo(
+            ObserverInfo(
                 source=str(k),
                 num_files_transferred=v._files_transferred,
                 num_files_in_queue=v.queue.qsize(),
@@ -264,11 +264,11 @@ def get_rsyncer_info(session_id: MurfeySessionID) -> list[RSyncerInfo]:
 
 
 @router.get("/sessions/{session_id}/analyser_info")
-def get_analyser_info(session_id: MurfeySessionID) -> list[RSyncerInfo]:
+def get_analyser_info(session_id: MurfeySessionID) -> list[ObserverInfo]:
     info = []
     for k, v in controllers[session_id].analysers.items():
         info.append(
-            RSyncerInfo(
+            ObserverInfo(
                 source=str(k),
                 num_files_transferred=0,
                 num_files_in_queue=v.queue.qsize(),

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -263,6 +263,22 @@ def get_rsyncer_info(session_id: MurfeySessionID) -> list[RSyncerInfo]:
     return info
 
 
+@router.get("/sessions/{session_id}/analyser_info")
+def get_analyser_info(session_id: MurfeySessionID) -> list[RSyncerInfo]:
+    info = []
+    for k, v in controllers[session_id].analysers.items():
+        info.append(
+            RSyncerInfo(
+                source=str(k),
+                num_files_transferred=0,
+                num_files_in_queue=v.queue.qsize(),
+                alive=v.thread.is_alive(),
+                stopping=v._stopping,
+            )
+        )
+    return info
+
+
 class ProcessingParameters(BaseModel):
     gain_ref: str
     dose_per_frame: Optional[float] = None


### PR DESCRIPTION
This adds the length and status of any corresponding analyser queue to the information returned about an rsyncer.

I've ended up breaking the one-to-one relation between endpoints in `server/api/instrument.py` and `instrument_server/api.py`, but this seemed the easiest way to combine the rsyncer and analyser information.