### PR TITLE
Remove the manual tilt offset from the user parameters, and the table which contains it

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -24,7 +24,7 @@ from murfey.client.rsync import RSyncerUpdate, TransferResult
 from murfey.client.tui.forms import FormDependency
 from murfey.util import Observer, get_machine_config_client
 from murfey.util.mdoc import get_block
-from murfey.util.models import PreprocessingParametersTomo, ProcessingParametersSPA
+from murfey.util.models import ProcessingParametersSPA, ProcessingParametersTomo
 
 logger = logging.getLogger("murfey.client.analyser")
 
@@ -65,7 +65,7 @@ class Analyser(Observer):
         self._environment = environment
         self._force_mdoc_metadata = force_mdoc_metadata
         self.parameters_model: (
-            Type[ProcessingParametersSPA] | Type[PreprocessingParametersTomo] | None
+            Type[ProcessingParametersSPA] | Type[ProcessingParametersTomo] | None
         ) = None
 
         self.queue: queue.Queue = queue.Queue()
@@ -183,7 +183,7 @@ class Analyser(Observer):
                 if not self._context:
                     logger.info("Acquisition software: tomo")
                     self._context = TomographyContext("tomo", self._basepath)
-                    self.parameters_model = PreprocessingParametersTomo
+                    self.parameters_model = ProcessingParametersTomo
                 return True
 
             # Files with these suffixes belong to the serial EM tomography workflow
@@ -207,7 +207,7 @@ class Analyser(Observer):
                 ):
                     return False
                 self._context = TomographyContext("serialem", self._basepath)
-                self.parameters_model = PreprocessingParametersTomo
+                self.parameters_model = ProcessingParametersTomo
                 return True
         return False
 

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -19,7 +19,6 @@ from murfey.client.instance_environment import (
 )
 from murfey.util import authorised_requests, capture_post, get_machine_config_client
 from murfey.util.mdoc import get_block, get_global_data, get_num_blocks
-from murfey.util.tomo import midpoint
 
 logger = logging.getLogger("murfey.client.contexts.tomo")
 
@@ -68,7 +67,6 @@ class TomographyContext(Context):
         ProcessingParameter(
             "dose_per_frame", "Dose Per Frame (e- / Angstrom^2 / frame)", default=1
         ),
-        ProcessingParameter("manual_tilt_offset", "Tilt Offset", default=0),
         ProcessingParameter("gain_ref", "Gain Reference"),
         ProcessingParameter("eer_fractionation", "EER Fractionation", default=20),
     ]
@@ -566,7 +564,6 @@ class TomographyContext(Context):
                         if environment
                         else None
                     )
-                    metadata["manual_tilt_offset"] = 0
                     metadata["source"] = str(self._basepath)
                 except KeyError:
                     return OrderedDict({})
@@ -626,9 +623,6 @@ class TomographyContext(Context):
                 environment.data_collection_parameters.get("dose_per_frame")
                 if environment
                 else None
-            )
-            mdoc_metadata["manual_tilt_offset"] = -midpoint(
-                [float(b["TiltAngle"]) for b in blocks]
             )
             mdoc_metadata["source"] = str(self._basepath)
             mdoc_metadata["tag"] = str(self._basepath)

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -438,7 +438,7 @@ class MultigridController:
                 eer_fractionation_file = eer_response.json()["eer_fractionation_file"]
                 json.update({"eer_fractionation_file": eer_fractionation_file})
             capture_post(
-                f"{self._environment.url.geturl()}/sessions/{self._environment.murfey_session}/tomography_preprocessing_parameters",
+                f"{self._environment.url.geturl()}/sessions/{self._environment.murfey_session}/tomography_processing_parameters",
                 json=json,
             )
             capture_post(

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -411,12 +411,6 @@ class MultigridController:
         source = Path(json["source"])
         context = self.analysers[source]._context
         if isinstance(context, TomographyContext):
-            if from_form:
-                capture_post(
-                    f"{self._environment.url.geturl()}/clients/{self._environment.client_id}/tomography_processing_parameters",
-                    json=json,
-                )
-
             source = Path(json["source"])
             context.register_tomography_data_collections(
                 file_extension=json["file_extension"],

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -504,7 +504,7 @@ class MurfeyTUI(App):
                 eer_fractionation_file = eer_response.json()["eer_fractionation_file"]
                 json.update({"eer_fractionation_file": eer_fractionation_file})
             requests.post(
-                f"{self.app._environment.url.geturl()}/sessions/{self.app._environment.murfey_session}/tomography_preprocessing_parameters",
+                f"{self.app._environment.url.geturl()}/sessions/{self.app._environment.murfey_session}/tomography_processing_parameters",
                 json=json,
             )
             capture_post(

--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -57,7 +57,7 @@ from murfey.client.instance_environment import (
 from murfey.client.rsync import RSyncer
 from murfey.client.tui.forms import FormDependency
 from murfey.util import capture_post, get_machine_config_client, posix_path, read_config
-from murfey.util.models import PreprocessingParametersTomo, ProcessingParametersSPA
+from murfey.util.models import ProcessingParametersSPA, ProcessingParametersTomo
 
 log = logging.getLogger("murfey.tui.screens")
 
@@ -463,7 +463,7 @@ class ProcessingForm(Screen):
     def _write_params(
         self,
         params: dict | None = None,
-        model: PreprocessingParametersTomo | ProcessingParametersSPA | None = None,
+        model: ProcessingParametersTomo | ProcessingParametersSPA | None = None,
     ):
         if params:
             try:
@@ -473,9 +473,9 @@ class ProcessingForm(Screen):
             for k in analyser._context.user_params + analyser._context.metadata_params:
                 self.app.query_one("#info").write(f"{k.label}: {params.get(k.name)}")
             self.app._start_dc(params)
-            if model == PreprocessingParametersTomo:
+            if model == ProcessingParametersTomo:
                 requests.post(
-                    f"{self.app._environment.url.geturl()}/sessions/{self.app._environment.murfey_session}/tomography_preprocessing_parameters",
+                    f"{self.app._environment.url.geturl()}/sessions/{self.app._environment.murfey_session}/tomography_processing_parameters",
                     json=params,
                 )
             elif model == ProcessingParametersSPA:
@@ -1156,9 +1156,7 @@ class DestinationSelect(Screen):
     def on_button_pressed(self, event):
         if self.app._multigrid and self.app._processing_enabled:
             if self._context == TomographyContext:
-                valid = validate_form(
-                    self._user_params, PreprocessingParametersTomo.Base
-                )
+                valid = validate_form(self._user_params, ProcessingParametersTomo.Base)
             else:
                 valid = validate_form(self._user_params, ProcessingParametersSPA.Base)
             if not valid:

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -190,15 +190,6 @@ def get_job_ids(tilt_series_id: int, appid: int) -> JobIDs:
     )
 
 
-def get_tomo_proc_params(pj_id: int, *args) -> db.TomographyProcessingParameters:
-    results = murfey_db.exec(
-        select(db.TomographyProcessingParameters).where(
-            db.TomographyProcessingParameters.pj_id == pj_id
-        )
-    ).one()
-    return results
-
-
 def get_tomo_preproc_params(dcg_id: int, *args) -> db.TomographyPreprocessingParameters:
     results = murfey_db.exec(
         select(db.TomographyPreprocessingParameters).where(

--- a/src/murfey/server/__init__.py
+++ b/src/murfey/server/__init__.py
@@ -190,10 +190,10 @@ def get_job_ids(tilt_series_id: int, appid: int) -> JobIDs:
     )
 
 
-def get_tomo_preproc_params(dcg_id: int, *args) -> db.TomographyPreprocessingParameters:
+def get_tomo_preproc_params(dcg_id: int, *args) -> db.TomographyProcessingParameters:
     results = murfey_db.exec(
-        select(db.TomographyPreprocessingParameters).where(
-            db.TomographyPreprocessingParameters.dcg_id == dcg_id
+        select(db.TomographyProcessingParameters).where(
+            db.TomographyProcessingParameters.dcg_id == dcg_id
         )
     ).one()
     return results
@@ -2537,11 +2537,11 @@ def feedback_callback(header: dict, message: dict) -> None:
                 .where(db.ProcessingJob.recipe == "em-tomo-preprocess")
             ).one()
             if not murfey_db.exec(
-                select(func.count(db.TomographyPreprocessingParameters.dcg_id)).where(
-                    db.TomographyPreprocessingParameters.dcg_id == collected_ids[0].id
+                select(func.count(db.TomographyProcessingParameters.dcg_id)).where(
+                    db.TomographyProcessingParameters.dcg_id == collected_ids[0].id
                 )
             ).one():
-                params = db.TomographyPreprocessingParameters(
+                params = db.TomographyProcessingParameters(
                     dcg_id=collected_ids[0].id,
                     pixel_size=float(message["pixel_size_on_image"]) * 10**10,
                     voltage=message["voltage"],

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -88,9 +88,9 @@ from murfey.util.models import (
     GridSquareParameters,
     MillingParameters,
     PostInfo,
-    PreprocessingParametersTomo,
     ProcessingJobParameters,
     ProcessingParametersSPA,
+    ProcessingParametersTomo,
     RegistrationMessage,
     RsyncerInfo,
     RsyncerSource,
@@ -613,9 +613,9 @@ def post_foil_hole(
     return register_foil_hole(session_id, gs_name, foil_hole_params, db)
 
 
-@router.post("/sessions/{session_id}/tomography_preprocessing_parameters")
+@router.post("/sessions/{session_id}/tomography_processing_parameters")
 def register_tomo_preproc_params(
-    session_id: MurfeySessionID, proc_params: PreprocessingParametersTomo, db=murfey_db
+    session_id: MurfeySessionID, proc_params: ProcessingParametersTomo, db=murfey_db
 ):
     session_processing_parameters = db.exec(
         select(SessionProcessingParameters).where(

--- a/src/murfey/server/demo_api.py
+++ b/src/murfey/server/demo_api.py
@@ -57,7 +57,7 @@ from murfey.util.db import (
     SPARelionParameters,
     Tilt,
     TiltSeries,
-    TomographyPreprocessingParameters,
+    TomographyProcessingParameters,
 )
 from murfey.util.models import (
     ClientInfo,
@@ -71,9 +71,9 @@ from murfey.util.models import (
     GainReference,
     GridSquareParameters,
     PostInfo,
-    PreprocessingParametersTomo,
     ProcessingJobParameters,
     ProcessingParametersSPA,
+    ProcessingParametersTomo,
     RegistrationMessage,
     RsyncerInfo,
     RsyncerSource,
@@ -477,9 +477,9 @@ def register_spa_proc_params(
     db.commit()
 
 
-@router.post("/sessions/{session_id}/tomography_preprocessing_parameters")
+@router.post("/sessions/{session_id}/tomography_processing_parameters")
 def register_tomo_preproc_params(
-    session_id: MurfeySessionID, proc_params: PreprocessingParametersTomo, db=murfey_db
+    session_id: MurfeySessionID, proc_params: ProcessingParametersTomo, db=murfey_db
 ):
     log.info(
         f"Registering tomography preprocessing parameters {sanitise(proc_params.tag)}, {sanitise(proc_params.tilt_series_tag)}"
@@ -500,11 +500,11 @@ def register_tomo_preproc_params(
         .where(ProcessingJob.recipe == "em-tomo-preprocess")
     ).one()
     if not db.exec(
-        select(func.count(TomographyPreprocessingParameters.dcg_id)).where(
-            TomographyPreprocessingParameters.dcg_id == collected_ids[0].id
+        select(func.count(TomographyProcessingParameters.dcg_id)).where(
+            TomographyProcessingParameters.dcg_id == collected_ids[0].id
         )
     ).one():
-        params = TomographyPreprocessingParameters(
+        params = TomographyProcessingParameters(
             dcg_id=collected_ids[0].id,
             pixel_size=proc_params.pixel_size_on_image,
             dose_per_frame=proc_params.dose_per_frame,

--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -378,7 +378,7 @@ class DataCollectionGroup(SQLModel, table=True):  # type: ignore
         back_populates="data_collection_group",
         sa_relationship_kwargs={"cascade": "delete"},
     )
-    tomography_preprocessing_parameters: List["TomographyPreprocessingParameters"] = (
+    tomography_processing_parameters: List["TomographyProcessingParameters"] = (
         Relationship(
             back_populates="data_collection_group",
             sa_relationship_kwargs={"cascade": "delete"},
@@ -493,7 +493,7 @@ class SelectionStash(SQLModel, table=True):  # type: ignore
     )
 
 
-class TomographyPreprocessingParameters(SQLModel, table=True):  # type: ignore
+class TomographyProcessingParameters(SQLModel, table=True):  # type: ignore
     dcg_id: int = Field(primary_key=True, foreign_key="datacollectiongroup.id")
     pixel_size: float
     dose_per_frame: float
@@ -504,7 +504,7 @@ class TomographyPreprocessingParameters(SQLModel, table=True):  # type: ignore
     motion_corr_binning: int = 1
     gain_ref: Optional[str] = None
     data_collection_group: Optional[DataCollectionGroup] = Relationship(
-        back_populates="tomography_preprocessing_parameters"
+        back_populates="tomography_processing_parameters"
     )
 
 

--- a/src/murfey/util/db.py
+++ b/src/murfey/util/db.py
@@ -448,12 +448,6 @@ class ProcessingJob(SQLModel, table=True):  # type: ignore
     spa_feedback_parameters: List["SPAFeedbackParameters"] = Relationship(
         back_populates="processing_job", sa_relationship_kwargs={"cascade": "delete"}
     )
-    tomography_processing_parameters: List["TomographyProcessingParameters"] = (
-        Relationship(
-            back_populates="processing_job",
-            sa_relationship_kwargs={"cascade": "delete"},
-        )
-    )
     ctf_parameters: List["CtfParameters"] = Relationship(
         back_populates="processing_job", sa_relationship_kwargs={"cascade": "delete"}
     )
@@ -511,14 +505,6 @@ class TomographyPreprocessingParameters(SQLModel, table=True):  # type: ignore
     gain_ref: Optional[str] = None
     data_collection_group: Optional[DataCollectionGroup] = Relationship(
         back_populates="tomography_preprocessing_parameters"
-    )
-
-
-class TomographyProcessingParameters(SQLModel, table=True):  # type: ignore
-    pj_id: int = Field(primary_key=True, foreign_key="processingjob.id")
-    manual_tilt_offset: int
-    processing_job: Optional[ProcessingJob] = Relationship(
-        back_populates="tomography_processing_parameters"
     )
 
 

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -372,9 +372,3 @@ class PreprocessingParametersTomo(BaseModel):
         gain_ref: Optional[str]
         manual_tilt_offset: float
         eer_fractionation: int
-
-
-class ProcessingParametersTomo(BaseModel):
-    manual_tilt_offset: int
-    tag: str
-    tilt_series_tag: str

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -360,7 +360,6 @@ class PreprocessingParametersTomo(BaseModel):
     image_size_y: int
     pixel_size_on_image: str
     motion_corr_binning: int
-    manual_tilt_offset: float
     file_extension: str
     tag: str
     tilt_series_tag: str
@@ -370,5 +369,4 @@ class PreprocessingParametersTomo(BaseModel):
     class Base(BaseModel):
         dose_per_frame: Optional[float]
         gain_ref: Optional[str]
-        manual_tilt_offset: float
         eer_fractionation: int

--- a/src/murfey/util/models.py
+++ b/src/murfey/util/models.py
@@ -349,7 +349,7 @@ class CompletedTiltSeries(BaseModel):
     rsync_source: str
 
 
-class PreprocessingParametersTomo(BaseModel):
+class ProcessingParametersTomo(BaseModel):
     dose_per_frame: Optional[float]
     frame_count: int
     tilt_axis: float


### PR DESCRIPTION
We had a `TomographyProcessingParameters` table in the database which just contained the tilt offset. This removes that table and renames the `TomographyPreprocessingParameters` to just be `TomographyProcessingParameters`.

I've also removed `manual_tilt_offset` from the client side entirely, as it is calculated server-side. I expect that will mean it disappears from the TUI display.

The renaming in particular is a high-risk change, which needs a test build and run before we can say this works.