### PR TITLE
Modified API endpoint that RsyncInstance deletion requests are sent to

### DIFF
--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 import aiohttp
 import requests
@@ -189,9 +189,7 @@ class MultigridController:
 
     def _rsyncer_stopped(self, source: Path, explicit_stop: bool = False):
         if explicit_stop:
-            remove_url = (
-                f"{self.murfey_url}/sessions/{self.session_id}/rsyncer/{str(source)}"
-            )
+            remove_url = f"{self.murfey_url}/sessions/{self.session_id}/rsyncer?source={quote(str(source), safe='')}"
             requests.delete(remove_url)
         else:
             stop_url = f"{self.murfey_url}/sessions/{self.session_id}/rsyncer_stopped"

--- a/src/murfey/server/api/__init__.py
+++ b/src/murfey/server/api/__init__.py
@@ -296,15 +296,22 @@ def register_rsyncer(session_id: int, rsyncer_info: RsyncerInfo, db=murfey_db):
     return rsyncer_info
 
 
-@router.delete("/sessions/{session_id}/rsyncer/{source:path}")
-def delete_rsyncer(session_id: int, source: str, db=murfey_db):
-    rsync_instance = db.exec(
-        select(RsyncInstance)
-        .where(RsyncInstance.session_id == session_id)
-        .where(RsyncInstance.source == source)
-    ).one()
-    db.delete(rsync_instance)
-    db.commit()
+@router.delete("/sessions/{session_id}/rsyncer")
+def delete_rsyncer(session_id: int, source: Path, db=murfey_db):
+    try:
+        rsync_instance = db.exec(
+            select(RsyncInstance)
+            .where(RsyncInstance.session_id == session_id)
+            .where(RsyncInstance.source == str(source))
+        ).one()
+        db.delete(rsync_instance)
+        db.commit()
+    except Exception:
+        log.error(
+            f"Failed to delete rsyncer for source directory {sanitise(str(source))!r} "
+            f"in session {session_id}.",
+            exc_info=True,
+        )
 
 
 @router.post("/sessions/{session_id}/rsyncer_stopped")


### PR DESCRIPTION
Passing paths in the URL to a FastAPI endpoint will cause leading '/' in Unix-style paths to be removed. Passing the path as a properly quoted/escaped query component in the URL will prevent this from occurring.

Also added a log to capture information about what source and session ID the request fails on.