### PR TITLE
Allow a controller to be "abandoned"

### DIFF
--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -122,6 +122,14 @@ class MultigridController:
                     log.warning(f"Could not delete database data for {self.session_id}")
                 self.dormant = True
 
+    def abandon(self):
+        for a in self.analysers.values():
+            a.request_stop()
+        for w in self._environment.watchers.values():
+            w.request_stop()
+        for p in self.rsync_processes.values():
+            p.request_stop()
+
     def finalise(self):
         for a in self.analysers.values():
             a.request_stop()

--- a/src/murfey/client/rsync.py
+++ b/src/murfey/client/rsync.py
@@ -182,6 +182,10 @@ class RSyncer(Observer):
             self.thread.join()
         logger.debug("RSync thread stop completed")
 
+    def request_stop(self):
+        self._stopping = True
+        self._halt_thread = True
+
     def finalise(
         self,
         thread: bool = True,

--- a/src/murfey/instrument_server/api.py
+++ b/src/murfey/instrument_server/api.py
@@ -220,6 +220,12 @@ def remove_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource):
     return {"success": True}
 
 
+@router.post("/sessions/{session_id}/abandon_controller")
+def abandon_controller(session_id: MurfeySessionID):
+    controllers[session_id].abandon()
+    return {"success": True}
+
+
 @router.post("/sessions/{session_id}/finalise_rsyncer")
 def finalise_rsyncer(session_id: MurfeySessionID, rsyncer_source: RsyncerSource):
     controllers[session_id]._finalise_rsyncer(rsyncer_source.source)

--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -395,6 +395,27 @@ async def finalise_session(session_id: MurfeySessionID, db=murfey_db):
     return data
 
 
+@router.post("/sessions/{session_id}/abandon_session")
+async def abandon_session(session_id: MurfeySessionID, db=murfey_db):
+    data = {}
+    instrument_name = (
+        db.exec(select(Session).where(Session.id == session_id)).one().instrument_name
+    )
+    machine_config = get_machine_config(instrument_name=instrument_name)[
+        instrument_name
+    ]
+    if machine_config.instrument_server_url:
+        async with aiohttp.ClientSession() as clientsession:
+            async with clientsession.post(
+                f"{machine_config.instrument_server_url}/sessions/{session_id}/abandon_controller",
+                headers={
+                    "Authorization": f"Bearer {instrument_server_tokens[session_id]['access_token']}"
+                },
+            ) as resp:
+                data = await resp.json()
+    return data
+
+
 @router.post("/sessions/{session_id}/remove_rsyncer")
 async def remove_rsyncer(
     session_id: MurfeySessionID, rsyncer_source: RsyncerSource, db=murfey_db


### PR DESCRIPTION
i.e. all associated threads stopped but no cleanup actions for the `rsync` processes