### PR TITLE
Forgot to include TEM instance of instrument server Helm chart in bumpversion's scope

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -24,6 +24,11 @@ search = 'version: {current_version}'
 replace = 'version: {new_version}'
 
 [[tool.bumpversion.files]]
+filename = "Helm/charts/murfey-instrument-server-tem/Chart.yaml"
+search = 'version: {current_version}'
+replace = 'version: {new_version}'
+
+[[tool.bumpversion.files]]
 filename = "Helm/charts/murfey-rsync/Chart.yaml"
 search = 'version: {current_version}'
 replace = 'version: {new_version}'

--- a/Helm/charts/murfey-instrument-server-tem/Chart.yaml
+++ b/Helm/charts/murfey-instrument-server-tem/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 name: murfey-instrument-server-tem
 description: Helm chart for deploying a Murfey instrument server, which executes orders to detect, modify, and transfer files on the instrument PC, and notifies the backend server about transferred files
-version: 0.16.12
+version: 0.17.10


### PR DESCRIPTION
Oopsies.