### PR TITLE
Move `auth_url` from machine configuration to security configuration

### DIFF
--- a/src/murfey/server/api/auth.py
+++ b/src/murfey/server/api/auth.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import secrets
 import time
 from logging import getLogger
@@ -19,7 +18,7 @@ from sqlmodel import Session, create_engine, select
 
 from murfey.server import sanitise
 from murfey.server.murfey_db import murfey_db, url
-from murfey.util.config import get_machine_config, get_security_config
+from murfey.util.config import get_security_config
 from murfey.util.db import MurfeyUser as User
 from murfey.util.db import Session as MurfeySession
 
@@ -64,12 +63,7 @@ class CookieScheme(HTTPBearer):
 
 # Set up variables used for authentication
 security_config = get_security_config()
-machine_config = get_machine_config()
-auth_url = (
-    machine_config[os.getenv("BEAMLINE", "")].auth_url
-    if machine_config.get(os.getenv("BEAMLINE", ""))
-    else ""
-)
+auth_url = security_config.auth_url
 ALGORITHM = security_config.auth_algorithm or "HS256"
 SECRET_KEY = security_config.auth_key or secrets.token_hex(32)
 if security_config.auth_type == "password":

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -68,7 +68,6 @@ class MachineConfig(BaseModel, extra=Extra.allow):  # type: ignore
     rsync_url: str = ""
 
     security_configuration_path: Optional[Path] = None
-    auth_url: str = ""
 
     notifications_queue: str = "pato_notification"
 
@@ -88,6 +87,7 @@ class Security(BaseModel):
     crypto_key: str
     auth_key: str = ""
     auth_algorithm: str = ""
+    auth_url: str = ""
     sqlalchemy_pooling: bool = True
     allow_origins: List[str] = ["*"]
     session_validation: str = ""


### PR DESCRIPTION
This should logically be here so that we can use a service for authorisation from a centralised server