### PR TITLE
Remove the assumption of a raw directory for processed outputs

### DIFF
--- a/src/murfey/server/api/workflow.py
+++ b/src/murfey/server/api/workflow.py
@@ -643,10 +643,14 @@ async def request_tomography_preprocessing(
     machine_config = get_machine_config(instrument_name=instrument_name)[
         instrument_name
     ]
-    visit_idx = Path(proc_file.path).parts.index(visit_name)
-    core = Path(*Path(proc_file.path).parts[: visit_idx + 1])
-    ppath = Path("/".join(secure_filename(p) for p in Path(proc_file.path).parts))
-    sub_dataset = "/".join(ppath.relative_to(core).parts[:-1])
+    parts = [secure_filename(p) for p in Path(proc_file.path).parts]
+    visit_idx = parts.index(visit_name)
+    core = Path("/") / Path(*parts[: visit_idx + 1])
+    ppath = Path("/") / Path(*parts)
+    if machine_config.process_multiple_datasets:
+        sub_dataset = ppath.relative_to(core).parts[0]
+    else:
+        sub_dataset = ""
     extra_path = machine_config.processed_extra_directory
     mrc_out = (
         core

--- a/src/murfey/server/api/workflow.py
+++ b/src/murfey/server/api/workflow.py
@@ -369,14 +369,11 @@ async def request_spa_preprocessing(
     visit_idx = parts.index(visit_name)
     core = Path("/") / Path(*parts[: visit_idx + 1])
     ppath = Path("/") / Path(*parts)
-    sub_dataset = ppath.relative_to(core).parts[0]
-    extra_path = machine_config.processed_extra_directory
-    for i, p in enumerate(ppath.parts):
-        if p.startswith("raw"):
-            movies_path_index = i
-            break
+    if machine_config.process_multiple_datasets:
+        sub_dataset = ppath.relative_to(core).parts[0]
     else:
-        raise ValueError(f"{proc_file.path} does not contain a raw directory")
+        sub_dataset = ""
+    extra_path = machine_config.processed_extra_directory
     mrc_out = (
         core
         / machine_config.processed_directory_name
@@ -385,7 +382,7 @@ async def request_spa_preprocessing(
         / "MotionCorr"
         / "job002"
         / "Movies"
-        / "/".join(ppath.parts[movies_path_index + 1 : -1])
+        / ppath.parent.relative_to(core / sub_dataset)
         / str(ppath.stem + "_motion_corrected.mrc")
     )
     try:

--- a/src/murfey/server/feedback.py
+++ b/src/murfey/server/feedback.py
@@ -113,7 +113,7 @@ def get_all_tilts(tilt_series_id: int) -> List[str]:
         instrument_name
     ]
     return [
-        motion_corrected_mrc(Path(r.movie_path), visit_name, machine_config)
+        str(motion_corrected_mrc(Path(r.movie_path), visit_name, machine_config))
         for r in results
     ]
 

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -57,6 +57,7 @@ class MachineConfig(BaseModel):  # type: ignore
     processing_enabled: bool = True
     process_by_default: bool = True
     gain_directory_name: str = "processing"
+    process_multiple_datasets: bool = True
     processed_directory_name: str = "processed"
     processed_extra_directory: str = ""
     recipes: dict[str, str] = {

--- a/src/murfey/util/processing_params.py
+++ b/src/murfey/util/processing_params.py
@@ -1,6 +1,36 @@
+from pathlib import Path
 from typing import Literal, Optional
 
 from pydantic import BaseModel
+from werkzeug.utils import secure_filename
+
+from murfey.util.config import MachineConfig
+
+
+def motion_corrected_mrc(
+    input_movie: Path, visit_name: str, machine_config: MachineConfig
+):
+    parts = [secure_filename(p) for p in input_movie.parts]
+    visit_idx = parts.index(visit_name)
+    core = Path("/") / Path(*parts[: visit_idx + 1])
+    ppath = Path("/") / Path(*parts)
+    if machine_config.process_multiple_datasets:
+        sub_dataset = ppath.relative_to(core).parts[0]
+    else:
+        sub_dataset = ""
+    extra_path = machine_config.processed_extra_directory
+    mrc_out = (
+        core
+        / machine_config.processed_directory_name
+        / sub_dataset
+        / extra_path
+        / "MotionCorr"
+        / "job002"
+        / "Movies"
+        / ppath.parent.relative_to(core / sub_dataset)
+        / str(ppath.stem + "_motion_corrected.mrc")
+    )
+    return Path("/".join(secure_filename(p) for p in mrc_out.parts))
 
 
 class CLEMAlignAndMergeParameters(BaseModel):


### PR DESCRIPTION
Resolves one of the doppio-live issues, where we assume a raw directory for SPA.

This instead makes it a configurable option, where the `raw` is added to the path if `process_multiple_datasets` is True, so that in cases such as eBIC where we send multiple datasets to one location they are still divided up.

Also makes the path construction consistent between SPA and tomo, which will need checking.