### PR TITLE
Post to data collection group hooks when the atlas is updated

### DIFF
--- a/src/murfey/server/api/workflow.py
+++ b/src/murfey/server/api/workflow.py
@@ -100,9 +100,11 @@ def register_dc_group(
         .where(DataCollectionGroup.session_id == session_id)
         .where(DataCollectionGroup.tag == dcg_params.tag)
     ).all():
-        dcg_murfey[0].atlas = dcg_params.atlas
-        dcg_murfey[0].sample = dcg_params.sample
-        dcg_murfey[0].atlas_pixel_size = dcg_params.atlas_pixel_size
+        dcg_murfey[0].atlas = dcg_params.atlas or dcg_murfey[0].atlas
+        dcg_murfey[0].sample = dcg_params.sample or dcg_murfey[0].sample
+        dcg_murfey[0].atlas_pixel_size = (
+            dcg_params.atlas_pixel_size or dcg_murfey[0].atlas_pixel_size
+        )
 
         if _transport_object:
             if dcg_murfey[0].atlas_id is not None:
@@ -114,6 +116,8 @@ def register_dc_group(
                         "atlas": dcg_params.atlas,
                         "sample": dcg_params.sample,
                         "atlas_pixel_size": dcg_params.atlas_pixel_size,
+                        "dcgid": dcg_murfey[0].id,
+                        "session_id": session_id,
                     },
                 )
             else:

--- a/src/murfey/server/feedback.py
+++ b/src/murfey/server/feedback.py
@@ -2032,6 +2032,16 @@ def feedback_callback(header: dict, message: dict) -> None:
                     message["sample"],
                 )
                 murfey.server._transport_object.transport.ack(header)
+            if dcg_hooks := entry_points().select(
+                group="murfey.hooks", name="data_collection_group"
+            ):
+                try:
+                    for hook in dcg_hooks:
+                        hook.load()(message["dcgid"], session_id=message["session_id"])
+                except Exception:
+                    logger.error(
+                        "Call to data collection group hook failed", exc_info=True
+                    )
             return None
         elif message["register"] == "data_collection":
             logger.debug(


### PR DESCRIPTION
For the Scaup sample tracking to work we need to update the data collection group hooks when we post new atlas information.