### PR TITLE
Fixed logic when passing empty 'visit_end_time' field to instrument server in 'setup_multigrid_watcher'

### DIFF
--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -127,7 +127,9 @@ async def setup_multigrid_watcher(
                         str(k): v for k, v in watcher_spec.destination_overrides.items()
                     },
                     "rsync_restarts": watcher_spec.rsync_restarts,
-                    "visit_end_time": str(session.visit_end_time),
+                    "visit_end_time": (
+                        str(session.visit_end_time) if session.visit_end_time else None
+                    ),
                 },
                 headers={
                     "Authorization": f"Bearer {instrument_server_tokens[session_id]['access_token']}"


### PR DESCRIPTION
`visit_end_time` is either a `datetime` object or `None`. `str(None)` is truth-y, and will fail the validation check on the instrument server side, since `"None"` cannot be evaluated into a `datetime` object. We thus need to pass in `None` as-is and only stringify `datetime` objects.