### PR TITLE
Do not error if the batch positions list is empty

### DIFF
--- a/src/murfey/client/contexts/tomo_metadata.py
+++ b/src/murfey/client/contexts/tomo_metadata.py
@@ -57,6 +57,9 @@ class TomographyMetadataContext(Context):
 
             windows_path = session_data["TomographySession"]["AtlasId"]
             logger.info(f"Windows path to atlas metadata found: {windows_path}")
+            if not windows_path:
+                logger.warning("No atlas metadata path found")
+                return
             visit_index = windows_path.split("\\").index(environment.visit)
             partial_path = "/".join(windows_path.split("\\")[visit_index + 1 :])
             logger.info("Partial Linux path successfully constructed from Windows path")


### PR DESCRIPTION
Very minor change. Currently the post transfer function gets an error when the batch positions list contains no positions, which this fixes.