### PR TITLE
Refactor API posts to send more information on failed posts

### DIFF
--- a/src/murfey/client/contexts/atlas.py
+++ b/src/murfey/client/contexts/atlas.py
@@ -6,7 +6,6 @@ from murfey.client.context import Context
 from murfey.client.contexts.spa import _get_source
 from murfey.client.contexts.spa_metadata import _atlas_destination
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_post
 
 logger = logging.getLogger("murfey.client.contexts.atlas")
@@ -40,8 +39,11 @@ class AtlasContext(Context):
                     environment, source, transferred_file
                 ) / transferred_file.relative_to(source.parent)
                 capture_post(
-                    f"{str(environment.url.geturl())}{url_path_for('session_control.spa_router', 'make_atlas_jpg', session_id=environment.murfey_session)}",
-                    json={"path": str(transferred_atlas_name)},
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.spa_router",
+                    function_name="make_atlas_jpg",
+                    session_id=environment.murfey_session,
+                    data={"path": str(transferred_atlas_name)},
                 )
                 logger.info(
                     f"Submitted request to create JPG image of atlas {str(transferred_atlas_name)!r}"

--- a/src/murfey/client/contexts/atlas.py
+++ b/src/murfey/client/contexts/atlas.py
@@ -2,18 +2,14 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import requests
-
 from murfey.client.context import Context
 from murfey.client.contexts.spa import _get_source
 from murfey.client.contexts.spa_metadata import _atlas_destination
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
 from murfey.util.api import url_path_for
-from murfey.util.client import authorised_requests, capture_post
+from murfey.util.client import capture_post
 
 logger = logging.getLogger("murfey.client.contexts.atlas")
-
-requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
 class AtlasContext(Context):

--- a/src/murfey/client/contexts/clem.py
+++ b/src/murfey/client/contexts/clem.py
@@ -13,7 +13,6 @@ from defusedxml.ElementTree import parse
 
 from murfey.client.context import Context
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_post, get_machine_config_client
 
 # Create logger object
@@ -353,19 +352,14 @@ class CLEMContext(Context):
         register the LIF file in the database correctly as part of the CLEM workflow.
         """
         try:
-            # Construct URL to post to post the request to
-            url = f"{environment.url.geturl()}{url_path_for('clem.router', 'register_lif_file', session_id=environment.murfey_session)}?lif_file={quote(str(lif_file), safe='')}"
-            # Validate
-            if not url:
-                logger.error(
-                    "URL could not be constructed from the environment and file path"
-                )
-                return False
-
-            # Send the message
-            capture_post(url)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="clem.router",
+                function_name="register_lif_file",
+                session_id=environment.murfey_session,
+                data={"lif_file": quote(str(lif_file), safe="")},
+            )
             return True
-
         except Exception as e:
             logger.error(
                 f"Error encountered when registering the LIF file in the database: {e}"
@@ -383,19 +377,14 @@ class CLEMContext(Context):
         """
 
         try:
-            # Construct the URL to post the request to
-            url = f"{environment.url.geturl()}{url_path_for('clem.router', 'process_raw_lifs', session_id=environment.murfey_session)}?lif_file={quote(str(lif_file), safe='')}"
-            # Validate
-            if not url:
-                logger.error(
-                    "URL could not be constructed from the environment and file path"
-                )
-                return False
-
-            # Send the message
-            capture_post(url)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="clem.router",
+                function_name="process_raw_lifs",
+                session_id=environment.murfey_session,
+                data={"lif_file": quote(str(lif_file), safe="")},
+            )
             return True
-
         except Exception as e:
             logger.error(f"Error encountered processing LIF file: {e}")
             return False
@@ -411,17 +400,14 @@ class CLEMContext(Context):
         """
 
         try:
-            url = f"{environment.url.geturl()}{url_path_for('clem.router', 'register_tiff_file', session_id=environment.murfey_session)}?tiff_file={quote(str(tiff_file), safe='')}"
-            if not url:
-                logger.error(
-                    "URL could not be constructed from the environment and file path"
-                )
-                return False
-
-            # Send the message
-            capture_post(url)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="clem.router",
+                function_name="register_tiff_file",
+                session_id=environment.murfey_session,
+                data={"tiff_file": quote(str(tiff_file), safe="")},
+            )
             return True
-
         except Exception as e:
             logger.error(
                 f"Error encountered when registering the TIFF file in the database: {e}"
@@ -439,18 +425,14 @@ class CLEMContext(Context):
         """
 
         try:
-            # Construct URL for Murfey server to communicate with
-            url = f"{environment.url.geturl()}{url_path_for('clem.router', 'process_raw_tiffs', session_id=environment.murfey_session)}"
-            if not url:
-                logger.error(
-                    "URL could not be constructed from the environment and file path"
-                )
-                return False
-
-            # Send the message
-            capture_post(url, json=tiff_dataset)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="clem.router",
+                function_name="process_raw_tiffs",
+                session_id=environment.murfey_session,
+                data=tiff_dataset,
+            )
             return True
-
         except Exception as e:
             logger.error(f"Error encountered processing the TIFF series: {e}")
             return False

--- a/src/murfey/client/contexts/fib.py
+++ b/src/murfey/client/contexts/fib.py
@@ -5,17 +5,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional
 
-import requests
 import xmltodict
 
 from murfey.client.context import Context
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
 from murfey.util.api import url_path_for
-from murfey.util.client import authorised_requests
+from murfey.util.client import capture_post
 
 logger = logging.getLogger("murfey.client.contexts.fib")
-
-requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
 class Lamella(NamedTuple):
@@ -95,8 +92,8 @@ class FIBContext(Context):
                         environment.default_destinations[self._basepath]
                     ).name
                     # post gif list to gif making API call
-                    requests.post(
-                        f"{environment.url.geturl()}{url_path_for('workflow.correlative_router', 'make_gif', year=datetime.now().year, visit_name=environment.visit, session_id=environment.murfey_session)}",
+                    capture_post(
+                        url=f"{environment.url.geturl()}{url_path_for('workflow.correlative_router', 'make_gif', year=datetime.now().year, visit_name=environment.visit, session_id=environment.murfey_session)}",
                         json={
                             "lamella_number": lamella_number,
                             "images": gif_list,

--- a/src/murfey/client/contexts/fib.py
+++ b/src/murfey/client/contexts/fib.py
@@ -9,7 +9,6 @@ import xmltodict
 
 from murfey.client.context import Context
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_post
 
 logger = logging.getLogger("murfey.client.contexts.fib")
@@ -93,8 +92,13 @@ class FIBContext(Context):
                     ).name
                     # post gif list to gif making API call
                     capture_post(
-                        url=f"{environment.url.geturl()}{url_path_for('workflow.correlative_router', 'make_gif', year=datetime.now().year, visit_name=environment.visit, session_id=environment.murfey_session)}",
-                        json={
+                        base_url=str(environment.url.geturl()),
+                        router_name="workflow.correlative_router",
+                        function_name="make_gif",
+                        year=datetime.now().year,
+                        visit_name=environment.visit,
+                        session_id=environment.murfey_session,
+                        data={
                             "lamella_number": lamella_number,
                             "images": gif_list,
                             "raw_directory": raw_directory,

--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -5,7 +5,6 @@ from itertools import count
 from pathlib import Path
 from typing import Any, Dict, List, Optional, OrderedDict, Tuple
 
-import requests
 import xmltodict
 
 from murfey.client.context import Context, ProcessingParameter
@@ -15,12 +14,7 @@ from murfey.client.instance_environment import (
     MurfeyInstanceEnvironment,
 )
 from murfey.util.api import url_path_for
-from murfey.util.client import (
-    authorised_requests,
-    capture_get,
-    capture_post,
-    get_machine_config_client,
-)
+from murfey.util.client import capture_get, capture_post, get_machine_config_client
 from murfey.util.spa_metadata import (
     foil_hole_data,
     foil_hole_from_file,
@@ -30,8 +24,6 @@ from murfey.util.spa_metadata import (
 )
 
 logger = logging.getLogger("murfey.client.contexts.spa")
-
-requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
 def _file_transferred_to(
@@ -304,7 +296,7 @@ class SPAModularContext(Context):
                 Optional[float],
             ] = (None, None, None, None, None, None, None)
             data_collection_group = (
-                requests.get(
+                capture_get(
                     f"{environment.url.geturl()}{url_path_for('session_info.router', 'get_dc_groups', session_id=environment.murfey_session)}"
                 )
                 .json()

--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -13,7 +13,6 @@ from murfey.client.instance_environment import (
     MurfeyID,
     MurfeyInstanceEnvironment,
 )
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_get, capture_post, get_machine_config_client
 from murfey.util.spa_metadata import (
     foil_hole_data,
@@ -227,7 +226,10 @@ class SPAModularContext(Context):
         binning_factor = 1
         if environment:
             server_config_response = capture_get(
-                f"{str(environment.url.geturl())}{url_path_for('session_control.router', 'machine_info_by_instrument', instrument_name=environment.instrument_name)}"
+                base_url=str(environment.url.geturl()),
+                router_name="session_control.router",
+                function_name="machine_info_by_instrument",
+                instrument_name=environment.instrument_name,
             )
             if server_config_response is None:
                 return None
@@ -297,7 +299,10 @@ class SPAModularContext(Context):
             ] = (None, None, None, None, None, None, None)
             data_collection_group = (
                 capture_get(
-                    f"{environment.url.geturl()}{url_path_for('session_info.router', 'get_dc_groups', session_id=environment.murfey_session)}"
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_info.router",
+                    function_name="get_dc_groups",
+                    session_id=environment.murfey_session,
                 )
                 .json()
                 .get(str(source), {})
@@ -319,7 +324,6 @@ class SPAModularContext(Context):
                         local_atlas_path,
                         grid_square=str(grid_square),
                     )[str(grid_square)]
-            gs_url = f"{str(environment.url.geturl())}{url_path_for('session_control.spa_router', 'register_grid_square', session_id=environment.murfey_session, gsid=grid_square)}"
             gs = grid_square_data(
                 grid_square_metadata_file,
                 grid_square,
@@ -340,8 +344,12 @@ class SPAModularContext(Context):
                 else ""
             )
             capture_post(
-                gs_url,
-                json={
+                base_url=str(environment.url.geturl()),
+                router_name="session_control.spa_router",
+                function_name="register_grid_square",
+                session_id=environment.murfey_session,
+                gsid=grid_square,
+                data={
                     "tag": str(source),
                     "readout_area_x": gs.readout_area_x,
                     "readout_area_y": gs.readout_area_y,
@@ -360,7 +368,6 @@ class SPAModularContext(Context):
             )
         foil_hole = foil_hole_from_file(transferred_file)
         if foil_hole not in self._foil_holes[grid_square]:
-            fh_url = f"{str(environment.url.geturl())}{url_path_for('session_control.spa_router', 'register_foil_hole', session_id=environment.murfey_session, gs_name=grid_square)}"
             if environment.murfey_session is not None:
                 fh = foil_hole_data(
                     grid_square_metadata_file,
@@ -383,8 +390,12 @@ class SPAModularContext(Context):
                     else ""
                 )
                 capture_post(
-                    fh_url,
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.spa_router",
+                    function_name="register_foil_hole",
+                    session_id=environment.murfey_session,
+                    gs_name=grid_square,
+                    data={
                         "name": foil_hole,
                         "x_location": fh.x_location,
                         "y_location": fh.y_location,
@@ -402,8 +413,12 @@ class SPAModularContext(Context):
                 )
             else:
                 capture_post(
-                    fh_url,
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.spa_router",
+                    function_name="register_foil_hole",
+                    session_id=environment.murfey_session,
+                    gs_name=grid_square,
+                    data={
                         "name": foil_hole,
                         "tag": str(source),
                     },
@@ -459,7 +474,9 @@ class SPAModularContext(Context):
                         )
                         if not environment.movie_counters.get(str(source)):
                             movie_counts_get = capture_get(
-                                f"{environment.url.geturl()}{url_path_for('session_control.router', 'count_number_of_movies')}",
+                                base_url=str(environment.url.geturl()),
+                                router_name="session_control.router",
+                                function_name="count_number_of_movies",
                             )
                             if movie_counts_get is not None:
                                 environment.movie_counters[str(source)] = count(
@@ -473,8 +490,12 @@ class SPAModularContext(Context):
                         eer_fractionation_file = None
                         if file_transferred_to.suffix == ".eer":
                             response = capture_post(
-                                f"{str(environment.url.geturl())}{url_path_for('file_io_instrument.router', 'write_eer_fractionation_file', visit_name=environment.visit, session_id=environment.murfey_session)}",
-                                json={
+                                base_url=str(environment.url.geturl()),
+                                router_name="file_io_instrument.router",
+                                function_name="write_eer_fractionation_file",
+                                visit_name=environment.visit,
+                                session_id=environment.murfey_session,
+                                data={
                                     "eer_path": str(file_transferred_to),
                                     "fractionation": self.data_collection_parameters[
                                         "eer_fractionation"
@@ -503,7 +524,6 @@ class SPAModularContext(Context):
                             )
                             foil_hole = None
 
-                        preproc_url = f"{str(environment.url.geturl())}{url_path_for('workflow.spa_router', 'request_spa_preprocessing', visit_name=environment.visit, session_id=environment.murfey_session)}"
                         preproc_data = {
                             "path": str(file_transferred_to),
                             "description": "",
@@ -529,8 +549,12 @@ class SPAModularContext(Context):
                             "foil_hole_id": foil_hole,
                         }
                         capture_post(
-                            preproc_url,
-                            json={
+                            base_url=str(environment.url.geturl()),
+                            router_name="workflow.spa_router",
+                            function_name="request_spa_preprocessing",
+                            visit_name=environment.visit,
+                            session_id=environment.murfey_session,
+                            data={
                                 k: None if v == "None" else v
                                 for k, v in preproc_data.items()
                             },

--- a/src/murfey/client/contexts/spa_metadata.py
+++ b/src/murfey/client/contexts/spa_metadata.py
@@ -2,18 +2,13 @@ import logging
 from pathlib import Path
 from typing import Dict, Optional
 
-import requests
 import xmltodict
 
 from murfey.client.context import Context
 from murfey.client.contexts.spa import _file_transferred_to, _get_source
 from murfey.client.instance_environment import MurfeyInstanceEnvironment, SampleInfo
 from murfey.util.api import url_path_for
-from murfey.util.client import (
-    authorised_requests,
-    capture_post,
-    get_machine_config_client,
-)
+from murfey.util.client import capture_post, get_machine_config_client
 from murfey.util.spa_metadata import (
     FoilHoleInfo,
     get_grid_square_atlas_positions,
@@ -21,8 +16,6 @@ from murfey.util.spa_metadata import (
 )
 
 logger = logging.getLogger("murfey.client.contexts.spa_metadata")
-
-requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
 def _foil_hole_positions(xml_path: Path, grid_square: int) -> Dict[str, FoilHoleInfo]:

--- a/src/murfey/client/contexts/spa_metadata.py
+++ b/src/murfey/client/contexts/spa_metadata.py
@@ -7,7 +7,6 @@ import xmltodict
 from murfey.client.context import Context
 from murfey.client.contexts.spa import _file_transferred_to, _get_source
 from murfey.client.instance_environment import MurfeyInstanceEnvironment, SampleInfo
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_post, get_machine_config_client
 from murfey.util.spa_metadata import (
     FoilHoleInfo,
@@ -160,7 +159,6 @@ class SPAMetadataContext(Context):
                 environment.samples[source] = SampleInfo(
                     atlas=Path(partial_path), sample=sample
                 )
-                url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'register_dc_group', visit_name=environment.visit, session_id=environment.murfey_session)}"
                 dcg_search_dir = "/".join(
                     p for p in transferred_file.parent.parts if p != environment.visit
                 )
@@ -189,15 +187,26 @@ class SPAMetadataContext(Context):
                     "sample": environment.samples[source].sample,
                     "atlas_pixel_size": atlas_pixel_size,
                 }
-                capture_post(url, json=dcg_data)
+                capture_post(
+                    base_url=str(environment.url.geturl()),
+                    router_name="workflow.router",
+                    function_name="register_dc_group",
+                    visit_name=environment.visit,
+                    session_id=environment.murfey_session,
+                    data=dcg_data,
+                )
                 gs_pix_positions = get_grid_square_atlas_positions(
                     source_visit_dir / partial_path
                 )
                 for gs, pos_data in gs_pix_positions.items():
                     if pos_data:
                         capture_post(
-                            f"{str(environment.url.geturl())}{url_path_for('session_control.spa_router', 'register_grid_square', session_id=environment.murfey_session, gsid=int(gs))}",
-                            json={
+                            base_url=str(environment.url.geturl()),
+                            router_name="session_control.spa_router",
+                            function_name="register_grid_square",
+                            session_id=environment.murfey_session,
+                            gsid=int(gs),
+                            data={
                                 "tag": dcg_tag,
                                 "x_location": pos_data[0],
                                 "y_location": pos_data[1],
@@ -215,7 +224,6 @@ class SPAMetadataContext(Context):
             and environment
         ):
             # Make sure we have a data collection group before trying to register grid square
-            url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'register_dc_group', visit_name=environment.visit, session_id=environment.murfey_session)}"
             dcg_search_dir = "/".join(
                 p
                 for p in transferred_file.parent.parent.parts
@@ -239,7 +247,14 @@ class SPAMetadataContext(Context):
                 "experiment_type_id": 37,
                 "tag": dcg_tag,
             }
-            capture_post(url, json=dcg_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.router",
+                function_name="register_dc_group",
+                visit_name=environment.visit,
+                session_id=environment.murfey_session,
+                data=dcg_data,
+            )
 
             gs_name = int(transferred_file.stem.split("_")[1])
             logger.info(
@@ -264,7 +279,6 @@ class SPAMetadataContext(Context):
             visitless_source = str(visitless_source_images_dirs[-1])
 
             if fh_positions:
-                gs_url = f"{str(environment.url.geturl())}{url_path_for('session_control.spa_router', 'register_grid_square', session_id=environment.murfey_session, gsid=gs_name)}"
                 gs_info = grid_square_data(
                     transferred_file,
                     gs_name,
@@ -275,8 +289,12 @@ class SPAMetadataContext(Context):
                     else ""
                 )
                 capture_post(
-                    gs_url,
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.spa_router",
+                    function_name="register_grid_square",
+                    session_id=environment.murfey_session,
+                    gsid=gs_name,
+                    data={
                         "tag": visitless_source,
                         "readout_area_x": gs_info.readout_area_x,
                         "readout_area_y": gs_info.readout_area_y,
@@ -289,8 +307,12 @@ class SPAMetadataContext(Context):
 
             for fh, fh_data in fh_positions.items():
                 capture_post(
-                    f"{str(environment.url.geturl())}{url_path_for('session_control.spa_router', 'register_foil_hole', session_id=environment.murfey_session, gs_name=gs_name)}",
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.spa_router",
+                    function_name="register_foil_hole",
+                    session_id=environment.murfey_session,
+                    gs_name=gs_name,
+                    data={
                         "name": fh,
                         "x_location": fh_data.x_location,
                         "y_location": fh_data.y_location,

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from threading import RLock
 from typing import Callable, Dict, List, OrderedDict
 
-import requests
 import xmltodict
 
 import murfey.util.eer
@@ -17,16 +16,10 @@ from murfey.client.instance_environment import (
     MurfeyInstanceEnvironment,
 )
 from murfey.util.api import url_path_for
-from murfey.util.client import (
-    authorised_requests,
-    capture_post,
-    get_machine_config_client,
-)
+from murfey.util.client import capture_get, capture_post, get_machine_config_client
 from murfey.util.mdoc import get_block, get_global_data, get_num_blocks
 
 logger = logging.getLogger("murfey.client.contexts.tomo")
-
-requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
 def _get_tilt_angle_v5_7(p: Path) -> str:
@@ -313,8 +306,8 @@ class TomographyContext(Context):
 
             eer_fractionation_file = None
             if self.data_collection_parameters.get("num_eer_frames"):
-                response = requests.post(
-                    f"{str(environment.url.geturl())}{url_path_for('file_io_instrument.router', 'write_eer_fractionation_file', visit_name=environment.visit, session_id=environment.murfey_session)}",
+                response = capture_post(
+                    url=f"{str(environment.url.geturl())}{url_path_for('file_io_instrument.router', 'write_eer_fractionation_file', visit_name=environment.visit, session_id=environment.murfey_session)}",
                     json={
                         "num_frames": self.data_collection_parameters["num_eer_frames"],
                         "fractionation": self.data_collection_parameters[
@@ -550,8 +543,8 @@ class TomographyContext(Context):
             superres_binning = int(mdoc_data_block["Binning"])
             binning_factor = 1
             if environment:
-                server_config = requests.get(
-                    f"{str(environment.url.geturl())}{url_path_for('session_control.router', 'machine_info_by_instrument', instrument_name=environment.instrument_name)}"
+                server_config = capture_get(
+                    url=f"{str(environment.url.geturl())}{url_path_for('session_control.router', 'machine_info_by_instrument', instrument_name=environment.instrument_name)}"
                 ).json()
                 if (
                     server_config.get("superres")

--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -15,7 +15,6 @@ from murfey.client.instance_environment import (
     MurfeyID,
     MurfeyInstanceEnvironment,
 )
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_get, capture_post, get_machine_config_client
 from murfey.util.mdoc import get_block, get_global_data, get_num_blocks
 
@@ -102,7 +101,6 @@ class TomographyContext(Context):
             )
             return
         try:
-            dcg_url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'register_dc_group', visit_name=environment.visit, session_id=environment.murfey_session)}"
             dcg_data = {
                 "experiment_type": "tomo",
                 "experiment_type_id": 36,
@@ -110,11 +108,17 @@ class TomographyContext(Context):
                 "atlas": "",
                 "sample": None,
             }
-            capture_post(dcg_url, json=dcg_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.router",
+                function_name="register_dc_group",
+                visit_name=environment.visit,
+                session_id=environment.murfey_session,
+                data=dcg_data,
+            )
 
             for tilt_series in self._tilt_series.keys():
                 if tilt_series not in self._tilt_series_with_pjids:
-                    dc_url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'start_dc', visit_name=environment.visit, session_id=environment.murfey_session)}"
                     dc_data = {
                         "experiment_type": "tomography",
                         "file_extension": file_extension,
@@ -146,13 +150,23 @@ class TomographyContext(Context):
                                 ],
                             }
                         )
-                        capture_post(dc_url, json=dc_data)
+                        capture_post(
+                            base_url=str(environment.url.geturl()),
+                            router_name="workflow.router",
+                            function_name="start_dc",
+                            visit_name=environment.visit,
+                            session_id=environment.murfey_session,
+                            data=dc_data,
+                        )
 
-                        proc_url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'register_proc', visit_name=environment.visit, session_id=environment.murfey_session)}"
                         for recipe in ("em-tomo-preprocess", "em-tomo-align"):
                             capture_post(
-                                proc_url,
-                                json={
+                                base_url=str(environment.url.geturl()),
+                                router_name="workflow.router",
+                                function_name="register_proc",
+                                visit_name=environment.visit,
+                                session_id=environment.murfey_session,
+                                data={
                                     "tag": tilt_series,
                                     "source": str(self._basepath),
                                     "recipe": recipe,
@@ -253,13 +267,18 @@ class TomographyContext(Context):
                 f"Tilt series {tilt_series} was previously thought complete but now {file_path} has been seen"
             )
             self._completed_tilt_series.remove(tilt_series)
-            rerun_url = f"{str(environment.url.geturl())}{url_path_for('workflow.tomo_router', 'register_tilt_series_for_rerun', visit_name=environment.visit)}"
             rerun_data = {
                 "session_id": environment.murfey_session,
                 "tag": tilt_series,
                 "source": str(file_path.parent),
             }
-            capture_post(rerun_url, json=rerun_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="register_tilt_series_for_rerun",
+                visit_name=environment.visit,
+                data=rerun_data,
+            )
             if tilt_series in self._aligned_tilt_series:
                 with self._lock:
                     self._aligned_tilt_series.remove(tilt_series)
@@ -267,13 +286,18 @@ class TomographyContext(Context):
         if not self._tilt_series.get(tilt_series):
             logger.info(f"New tilt series found: {tilt_series}")
             self._tilt_series[tilt_series] = [file_path]
-            ts_url = f"{str(environment.url.geturl())}{url_path_for('workflow.tomo_router', 'register_tilt_series', visit_name=environment.visit)}"
             ts_data = {
                 "session_id": environment.murfey_session,
                 "tag": tilt_series,
                 "source": str(file_path.parent),
             }
-            capture_post(ts_url, json=ts_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="register_tilt_series",
+                visit_name=environment.visit,
+                data=ts_data,
+            )
             if not self._tilt_series_sizes.get(tilt_series):
                 self._tilt_series_sizes[tilt_series] = 0
 
@@ -296,19 +320,29 @@ class TomographyContext(Context):
                     self._tilt_series[tilt_series].append(file_path)
 
         if environment:
-            tilt_url = f"{str(environment.url.geturl())}{url_path_for('workflow.tomo_router', 'register_tilt', visit_name=environment.visit, session_id=environment.murfey_session)}"
             tilt_data = {
                 "movie_path": str(file_transferred_to),
                 "tilt_series_tag": tilt_series,
                 "source": str(file_path.parent),
             }
-            capture_post(tilt_url, json=tilt_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="register_tilt",
+                visit_name=environment.visit,
+                session_id=environment.murfey_session,
+                data=tilt_data,
+            )
 
             eer_fractionation_file = None
             if self.data_collection_parameters.get("num_eer_frames"):
                 response = capture_post(
-                    url=f"{str(environment.url.geturl())}{url_path_for('file_io_instrument.router', 'write_eer_fractionation_file', visit_name=environment.visit, session_id=environment.murfey_session)}",
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="file_io_instrument.router",
+                    function_name="write_eer_fractionation_file",
+                    visit_name=environment.visit,
+                    session_id=environment.murfey_session,
+                    data={
                         "num_frames": self.data_collection_parameters["num_eer_frames"],
                         "fractionation": self.data_collection_parameters[
                             "eer_fractionation"
@@ -318,7 +352,6 @@ class TomographyContext(Context):
                     },
                 )
                 eer_fractionation_file = response.json()["eer_fractionation_file"]
-            preproc_url = f"{str(environment.url.geturl())}{url_path_for('workflow.tomo_router', 'request_tomography_preprocessing', visit_name=environment.visit, session_id=environment.murfey_session)}"
             preproc_data = {
                 "path": str(file_transferred_to),
                 "description": "",
@@ -338,7 +371,14 @@ class TomographyContext(Context):
                 "tag": tilt_series,
                 "group_tag": str(self._basepath),
             }
-            capture_post(preproc_url, json=preproc_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="request_tomography_preprocessing",
+                visit_name=environment.visit,
+                session_id=environment.murfey_session,
+                data=preproc_data,
+            )
 
         return self._check_tilt_series(tilt_series)
 
@@ -443,10 +483,12 @@ class TomographyContext(Context):
 
                     # Always update the tilt series length in the database after an mdoc
                     if environment.murfey_session is not None:
-                        length_url = f"{str(environment.url.geturl())}{url_path_for('workflow.tomo_router', 'register_tilt_series_length', session_id=environment.murfey_session)}"
                         capture_post(
-                            length_url,
-                            json={
+                            base_url=str(environment.url.geturl()),
+                            router_name="workflow.tomo_router",
+                            function_name="register_tilt_series_length",
+                            session_id=environment.murfey_session,
+                            data={
                                 "tags": [tilt_series],
                                 "source": str(transferred_file.parent),
                                 "tilt_series_lengths": [
@@ -460,10 +502,13 @@ class TomographyContext(Context):
                 f"The following tilt series are considered complete: {completed_tilts} "
                 f"after {transferred_file}"
             )
-            complete_url = f"{str(environment.url.geturl())}{url_path_for('workflow.tomo_router', 'register_completed_tilt_series', visit_name=environment.visit, session_id=environment.murfey_session)}"
             capture_post(
-                complete_url,
-                json={
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="register_completed_tilt_series",
+                visit_name=environment.visit,
+                session_id=environment.murfey_session,
+                data={
                     "tags": completed_tilts,
                     "source": str(transferred_file.parent),
                     "tilt_series_lengths": [
@@ -544,7 +589,10 @@ class TomographyContext(Context):
             binning_factor = 1
             if environment:
                 server_config = capture_get(
-                    url=f"{str(environment.url.geturl())}{url_path_for('session_control.router', 'machine_info_by_instrument', instrument_name=environment.instrument_name)}"
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.router",
+                    function_name="machine_info_by_instrument",
+                    instrument_name=environment.instrument_name,
                 ).json()
                 if (
                     server_config.get("superres")

--- a/src/murfey/client/contexts/tomo_metadata.py
+++ b/src/murfey/client/contexts/tomo_metadata.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-import requests
 import xmltodict
 
 from murfey.client.context import Context
@@ -10,11 +9,9 @@ from murfey.client.contexts.spa import _file_transferred_to, _get_source
 from murfey.client.contexts.spa_metadata import _atlas_destination
 from murfey.client.instance_environment import MurfeyInstanceEnvironment, SampleInfo
 from murfey.util.api import url_path_for
-from murfey.util.client import authorised_requests, capture_post
+from murfey.util.client import capture_post
 
 logger = logging.getLogger("murfey.client.contexts.tomo_metadata")
-
-requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
 def ensure_dcg_exists(transferred_file: Path, environment: MurfeyInstanceEnvironment):

--- a/src/murfey/client/contexts/tomo_metadata.py
+++ b/src/murfey/client/contexts/tomo_metadata.py
@@ -8,7 +8,6 @@ from murfey.client.context import Context
 from murfey.client.contexts.spa import _file_transferred_to, _get_source
 from murfey.client.contexts.spa_metadata import _atlas_destination
 from murfey.client.instance_environment import MurfeyInstanceEnvironment, SampleInfo
-from murfey.util.api import url_path_for
 from murfey.util.client import capture_post
 
 logger = logging.getLogger("murfey.client.contexts.tomo_metadata")
@@ -20,13 +19,19 @@ def ensure_dcg_exists(transferred_file: Path, environment: MurfeyInstanceEnviron
     if not source:
         return None
     dcg_tag = str(source).replace(f"/{environment.visit}", "")
-    url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'register_dc_group', visit_name=environment.visit, session_id=environment.murfey_session)}"
     dcg_data = {
         "experiment_type": "tomo",
         "experiment_type_id": 36,
         "tag": dcg_tag,
     }
-    capture_post(url, json=dcg_data)
+    capture_post(
+        base_url=str(environment.url.geturl()),
+        router_name="workflow.router",
+        function_name="register_dc_group",
+        visit_name=environment.visit,
+        session_id=environment.murfey_session,
+        data=dcg_data,
+    )
     return dcg_tag
 
 
@@ -95,7 +100,6 @@ class TomographyMetadataContext(Context):
             environment.samples[source] = SampleInfo(
                 atlas=Path(partial_path), sample=sample
             )
-            url = f"{str(environment.url.geturl())}{url_path_for('workflow.router', 'register_dc_group', visit_name=environment.visit, session_id=environment.murfey_session)}"
             dcg_tag = "/".join(
                 p for p in transferred_file.parent.parts if p != environment.visit
             ).replace("//", "/")
@@ -111,7 +115,14 @@ class TomographyMetadataContext(Context):
                 "sample": environment.samples[source].sample,
                 "atlas_pixel_size": atlas_pixel_size,
             }
-            capture_post(url, json=dcg_data)
+            capture_post(
+                base_url=str(environment.url.geturl()),
+                router_name="workflow.router",
+                function_name="register_dc_group",
+                visit_name=environment.visit,
+                session_id=environment.murfey_session,
+                data=dcg_data,
+            )
 
         elif transferred_file.name == "SearchMap.xml" and environment:
             logger.info("Tomography session search map xml found")
@@ -192,10 +203,13 @@ class TomographyMetadataContext(Context):
                 else ""
             )
 
-            sm_url = f"{str(environment.url.geturl())}{url_path_for('session_control.tomo_router', 'register_search_map', session_id=environment.murfey_session, sm_name=transferred_file.parent.name)}"
             capture_post(
-                sm_url,
-                json={
+                base_url=str(environment.url.geturl()),
+                router_name="session_control.tomo_router",
+                function_name="register_search_map",
+                session_id=environment.murfey_session,
+                sm_name=transferred_file.parent.name,
+                data={
                     "tag": dcg_tag,
                     "x_stage_position": float(stage_position["X"]),
                     "y_stage_position": float(stage_position["Y"]),
@@ -240,10 +254,13 @@ class TomographyMetadataContext(Context):
                     f"Inserting incorrect width {sm_width}, height {sm_height} for SearchMap display"
                 )
 
-            sm_url = f"{str(environment.url.geturl())}{url_path_for('session_control.tomo_router', 'register_search_map', session_id=environment.murfey_session, sm_name=transferred_file.parent.name)}"
             capture_post(
-                sm_url,
-                json={
+                base_url=str(environment.url.geturl()),
+                router_name="session_control.tomo_router",
+                function_name="register_search_map",
+                session_id=environment.murfey_session,
+                sm_name=transferred_file.parent.name,
+                data={
                     "tag": dcg_tag,
                     "height": sm_height,
                     "width": sm_width,
@@ -278,19 +295,25 @@ class TomographyMetadataContext(Context):
                 )
 
                 # Always need search map before batch position
-                sm_url = f"{str(environment.url.geturl())}{url_path_for('session_control.tomo_router', 'register_search_map', session_id=environment.murfey_session, sm_name=search_map_name)}"
                 capture_post(
-                    sm_url,
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.tomo_router",
+                    function_name="register_search_map",
+                    session_id=environment.murfey_session,
+                    sm_name=search_map_name,
+                    data={
                         "tag": dcg_tag,
                     },
                 )
 
                 # Then register batch position
-                bp_url = f"{str(environment.url.geturl())}{url_path_for('session_control.tomo_router', 'register_batch_position', session_id=environment.murfey_session, batch_name=batch_name)}"
                 capture_post(
-                    bp_url,
-                    json={
+                    base_url=str(environment.url.geturl()),
+                    router_name="session_control.tomo_router",
+                    function_name="register_batch_position",
+                    session_id=environment.murfey_session,
+                    batch_name=batch_name,
+                    data={
                         "tag": dcg_tag,
                         "x_stage_position": batch_stage_location_x,
                         "y_stage_position": batch_stage_location_y,
@@ -313,10 +336,13 @@ class TomographyMetadataContext(Context):
                         beamshift_position_y = float(beamshift["PositionY"])
 
                         # Registration of beamshifted position
-                        bp_url = f"{str(environment.url.geturl())}{url_path_for('session_control.tomo_router', 'register_batch_position', session_id=environment.murfey_session, batch_name=beamshift_name)}"
                         capture_post(
-                            bp_url,
-                            json={
+                            base_url=str(environment.url.geturl()),
+                            router_name="session_control.tomo_router",
+                            function_name="register_batch_position",
+                            session_id=environment.murfey_session,
+                            batch_name=beamshift_name,
+                            data={
                                 "tag": dcg_tag,
                                 "x_stage_position": batch_stage_location_x,
                                 "y_stage_position": batch_stage_location_y,

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from functools import partial
 from pathlib import Path
 from typing import Dict, List, Optional
-from urllib.parse import quote, urlparse
+from urllib.parse import urlparse
 
 import murfey.client.websocket
 from murfey.client.analyser import Analyser
@@ -19,7 +19,6 @@ from murfey.client.rsync import RSyncer, RSyncerUpdate, TransferResult
 from murfey.client.tui.screens import determine_default_destination
 from murfey.client.watchdir import DirWatcher
 from murfey.util import posix_path
-from murfey.util.api import url_path_for
 from murfey.util.client import (
     capture_delete,
     capture_get,
@@ -57,7 +56,10 @@ class MultigridController:
 
     def __post_init__(self):
         machine_data = capture_get(
-            url=f"{self.murfey_url}{url_path_for('session_control.router', 'machine_info_by_instrument', instrument_name=self.instrument_name)}"
+            base_url=self.murfey_url,
+            router_name="session_control.router",
+            function_name="machine_info_by_instrument",
+            instrument_name=self.instrument_name,
         ).json()
         self.rsync_url = machine_data.get("rsync_url", "")
         self.rsync_module = machine_data.get("rsync_module", "data")
@@ -100,7 +102,9 @@ class MultigridController:
         # Calculate the time offset between the client and the server
         current_time = datetime.now()
         server_timestamp = capture_get(
-            url=f"{self.murfey_url}{url_path_for('session_control.router', 'get_current_timestamp')}"
+            base_url=self.murfey_url,
+            router_name="session_control.router",
+            function_name="get_current_timestamp",
         ).json()["timestamp"]
         self.server_time_offset = current_time - datetime.fromtimestamp(
             server_timestamp
@@ -157,7 +161,10 @@ class MultigridController:
             f"Submitting request to remove session {self.session_id} from database"
         )
         response = capture_delete(
-            f"{self._environment.url.geturl()}{url_path_for('session_control.router', 'remove_session', session_id=self.session_id)}",
+            base_url=str(self._environment.url.geturl()),
+            router_name="session_control.router",
+            function_name="remove_session",
+            session_id=self.session_id,
         )
         success = response.status_code == 200 if response else False
         if not success:
@@ -229,7 +236,10 @@ class MultigridController:
         log.debug(f"Analysis of {source} is {('enabled' if analyse else 'disabled')}")
         destination_overrides = destination_overrides or {}
         machine_data = capture_get(
-            url=f"{self._environment.url.geturl()}{url_path_for('session_control.router', 'machine_info_by_instrument', instrument_name=self.instrument_name)}"
+            base_url=str(self._environment.url.geturl()),
+            router_name="session_control.router",
+            function_name="machine_info_by_instrument",
+            instrument_name=self.instrument_name,
         ).json()
         if destination_overrides.get(source):
             destination = (
@@ -281,11 +291,21 @@ class MultigridController:
 
     def _rsyncer_stopped(self, source: Path, explicit_stop: bool = False):
         if explicit_stop:
-            remove_url = f"{self.murfey_url}{url_path_for('session_control.router', 'delete_rsyncer', session_id=self.session_id)}?source={quote(str(source), safe='')}"
-            capture_delete(url=remove_url)
+            capture_delete(
+                base_url=self.murfey_url,
+                router_name="session_control.router",
+                function_name="delete_rsyncer",
+                session_id=self.session_id,
+                data={"path": str(source)},
+            )
         else:
-            stop_url = f"{self.murfey_url}{url_path_for('session_control.router', 'register_stopped_rsyncer', session_id=self.session_id)}"
-            capture_post(stop_url, json={"path": str(source)})
+            capture_post(
+                base_url=self.murfey_url,
+                router_name="session_control.router",
+                function_name="register_stopped_rsyncer",
+                session_id=self.session_id,
+                data={"path": str(source)},
+            )
 
     def _finalise_rsyncer(self, source: Path):
         """
@@ -304,8 +324,13 @@ class MultigridController:
 
     def _restart_rsyncer(self, source: Path):
         self.rsync_processes[source].restart()
-        restarted_url = f"{self.murfey_url}{url_path_for('session_control.router', 'register_restarted_rsyncer', session_id=self.session_id)}"
-        capture_post(restarted_url, json={"path": str(source)})
+        capture_post(
+            base_url=self.murfey_url,
+            router_name="session_control.router",
+            function_name="register_restarted_rsyncer",
+            session_id=self.session_id,
+            data={"path": str(source)},
+        )
 
     def _request_watcher_stop(self, source: Path):
         self._environment.watchers[source]._stopping = True
@@ -327,8 +352,13 @@ class MultigridController:
         log.info(f"starting rsyncer: {source}")
         if transfer:
             # Always make sure the destination directory exists
-            make_directory_url = f"{self.murfey_url}{url_path_for('file_io_instrument.router', 'make_rsyncer_destination', session_id=self.session_id)}"
-            capture_post(make_directory_url, json={"destination": destination})
+            capture_post(
+                base_url=self.murfey_url,
+                router_name="file_io_instrument.router",
+                function_name="make_rsyncer_destination",
+                session_id=self.session_id,
+                data={"destination": destination},
+            )
         if self._environment:
             self._environment.default_destinations[source] = destination
             if self._environment.gain_ref and visit_path:
@@ -397,10 +427,14 @@ class MultigridController:
                 secondary=True,
             )
             if restarted:
-                restarted_url = f"{self.murfey_url}{url_path_for('session_control.router', 'register_restarted_rsyncer', session_id=self.session_id)}"
-                capture_post(restarted_url, json={"path": str(source)})
+                capture_post(
+                    base_url=self.murfey_url,
+                    router_name="session_control.router",
+                    function_name="register_restarted_rsyncer",
+                    session_id=self.session_id,
+                    data={"path": str(source)},
+                )
             else:
-                url = f"{str(self._environment.url.geturl())}{url_path_for('session_control.router', 'register_rsyncer', session_id=self._environment.murfey_session)}"
                 rsyncer_data = {
                     "source": str(source),
                     "destination": destination,
@@ -408,7 +442,13 @@ class MultigridController:
                     "transferring": self.do_transfer or self._environment.demo,
                     "tag": tag,
                 }
-                capture_post(url=url, json=rsyncer_data)
+                capture_post(
+                    base_url=self.murfey_url,
+                    router_name="session_control.router",
+                    function_name="register_rsyncer",
+                    session_id=self._environment.murfey_session,
+                    data=rsyncer_data,
+                )
         self._environment.watchers[source] = DirWatcher(source, settling_time=30)
 
         if not self.analysers.get(source) and analyse:
@@ -513,8 +553,12 @@ class MultigridController:
             log.info("Registering tomography processing parameters")
             if context.data_collection_parameters.get("num_eer_frames"):
                 eer_response = capture_post(
-                    url=f"{str(self._environment.url.geturl())}{url_path_for('file_io_instrument.router', 'write_eer_fractionation_file', visit_name=self._environment.visit, session_id=self._environment.murfey_session)}",
-                    json={
+                    base_url=str(self._environment.url.geturl()),
+                    router_name="file_io_instrument.router",
+                    function_name="write_eer_fractionation_file",
+                    visit_name=self._environment.visit,
+                    session_id=self._environment.murfey_session,
+                    data={
                         "num_frames": context.data_collection_parameters[
                             "num_eer_frames"
                         ],
@@ -526,17 +570,23 @@ class MultigridController:
                 eer_fractionation_file = eer_response.json()["eer_fractionation_file"]
                 metadata_json.update({"eer_fractionation_file": eer_fractionation_file})
             capture_post(
-                f"{self._environment.url.geturl()}{url_path_for('workflow.tomo_router', 'register_tomo_proc_params', session_id=self._environment.murfey_session)}",
-                json=metadata_json,
+                base_url=str(self._environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="register_tomo_proc_params",
+                session_id=self._environment.murfey_session,
+                data=metadata_json,
             )
             capture_post(
-                f"{self._environment.url.geturl()}{url_path_for('workflow.tomo_router', 'flush_tomography_processing', visit_name=self._environment.visit, session_id=self._environment.murfey_session)}",
-                json={"rsync_source": str(source)},
+                base_url=str(self._environment.url.geturl()),
+                router_name="workflow.tomo_router",
+                function_name="flush_tomography_processing",
+                visit_name=self._environment.visit,
+                session_id=self._environment.murfey_session,
+                data={"rsync_source": str(source)},
             )
             log.info("Tomography processing flushed")
 
         elif isinstance(context, SPAModularContext):
-            url = f"{str(self._environment.url.geturl())}{url_path_for('workflow.router', 'register_dc_group', visit_name=self._environment.visit, session_id=self.session_id)}"
             dcg_data = {
                 "experiment_type": "single particle",
                 "experiment_type_id": 37,
@@ -552,7 +602,14 @@ class MultigridController:
                     else None
                 ),
             }
-            capture_post(url, json=dcg_data)
+            capture_post(
+                base_url=str(self._environment.url.geturl()),
+                router_name="workflow.router",
+                function_name="register_dc_group",
+                visit_name=self._environment.visit,
+                session_id=self.session_id,
+                data=dcg_data,
+            )
             if from_form:
                 data = {
                     "voltage": metadata_json["voltage"],
@@ -575,8 +632,12 @@ class MultigridController:
                     "phase_plate": metadata_json.get("phase_plate", False),
                 }
                 capture_post(
-                    f"{str(self._environment.url.geturl())}{url_path_for('workflow.router', 'start_dc', visit_name=self._environment.visit, session_id=self.session_id)}",
-                    json=data,
+                    base_url=str(self._environment.url.geturl()),
+                    router_name="workflow.router",
+                    function_name="start_dc",
+                    visit_name=self._environment.visit,
+                    session_id=self.session_id,
+                    data=data,
                 )
                 for recipe in (
                     "em-spa-preprocess",
@@ -586,8 +647,12 @@ class MultigridController:
                     "em-spa-refine",
                 ):
                     capture_post(
-                        f"{str(self._environment.url.geturl())}{url_path_for('workflow.router', 'register_proc', visit_name=self._environment.visit, session_id=self.session_id)}",
-                        json={
+                        base_url=str(self._environment.url.geturl()),
+                        router_name="workflow.router",
+                        function_name="register_proc",
+                        visit_name=self._environment.visit,
+                        session_id=self.session_id,
+                        data={
                             "tag": str(source),
                             "source": str(source),
                             "recipe": recipe,
@@ -595,8 +660,11 @@ class MultigridController:
                     )
                 log.info(f"Posting SPA processing parameters: {metadata_json}")
                 response = capture_post(
-                    f"{self._environment.url.geturl()}{url_path_for('workflow.spa_router', 'register_spa_proc_params', session_id=self.session_id)}",
-                    json={
+                    base_url=str(self._environment.url.geturl()),
+                    router_name="workflow.spa_router",
+                    function_name="register_spa_proc_params",
+                    session_id=self.session_id,
+                    data={
                         **{
                             k: None if v == "None" else v
                             for k, v in metadata_json.items()
@@ -607,14 +675,17 @@ class MultigridController:
                 if response and not str(response.status_code).startswith("2"):
                     log.warning(f"{response.reason}")
                 capture_post(
-                    f"{self._environment.url.geturl()}{url_path_for('workflow.spa_router', 'flush_spa_processing', visit_name=self._environment.visit, session_id=self.session_id)}",
-                    json={"tag": str(source)},
+                    base_url=str(self._environment.url.geturl()),
+                    router_name="workflow.spa_router",
+                    function_name="flush_spa_processing",
+                    visit_name=self._environment.visit,
+                    session_id=self.session_id,
+                    data={"tag": str(source)},
                 )
 
     def _increment_file_count(
         self, observed_files: List[Path], source: str, destination: str
     ):
-        url = f"{str(self._environment.url.geturl())}{url_path_for('prometheus.router', 'increment_rsync_file_count', visit_name=self._environment.visit)}"
         num_data_files = len(
             [
                 f
@@ -630,7 +701,13 @@ class MultigridController:
             "increment_count": len(observed_files),
             "increment_data_count": num_data_files,
         }
-        capture_post(url=url, json=data)
+        capture_post(
+            base_url=str(self._environment.url.geturl()),
+            router_name="prometheus.router",
+            function_name="increment_rsync_file_count",
+            visit_name=self._environment.visit,
+            data=data,
+        )
 
     # Prometheus can handle higher traffic so update for every transferred file rather
     # than batching as we do for the Murfey database updates in _increment_transferred_files
@@ -638,7 +715,6 @@ class MultigridController:
         self, update: RSyncerUpdate, source: str, destination: str
     ):
         if update.outcome is TransferResult.SUCCESS:
-            url = f"{str(self._environment.url.geturl())}{url_path_for('prometheus.router', 'increment_rsync_transferred_files_prometheus', visit_name=self._environment.visit)}"
             data_files = (
                 [update]
                 if update.file_path.suffix in self._data_suffixes
@@ -657,7 +733,13 @@ class MultigridController:
                 "increment_data_count": len(data_files),
                 "data_bytes": sum(f.file_size for f in data_files),
             }
-            capture_post(url=url, json=data)
+            capture_post(
+                base_url=str(self._environment.url.geturl()),
+                router_name="prometheus.router",
+                function_name="increment_rsync_transferred_files_prometheus",
+                visit_name=self._environment.visit,
+                data=data,
+            )
 
     def _increment_transferred_files(
         self,
@@ -666,10 +748,12 @@ class MultigridController:
         source: str,
         destination: str,
     ):
-        skip_url = f"{str(self._environment.url.geturl())}{url_path_for('prometheus.router', 'increment_rsync_skipped_files_prometheus', visit_name=self._environment.visit)}"
         capture_post(
-            url=skip_url,
-            json={
+            base_url=str(self._environment.url.geturl()),
+            router_name="prometheus.router",
+            function_name="increment_rsync_skipped_files_prometheus",
+            visit_name=self._environment.visit,
+            data={
                 "source": source,
                 "session_id": self.session_id,
                 "increment_count": num_skipped_files,
@@ -681,7 +765,6 @@ class MultigridController:
         ]
         if not checked_updates:
             return
-        url = f"{str(self._environment.url.geturl())}{url_path_for('prometheus.router', 'increment_rsync_transferred_files', visit_name=self._environment.visit)}"
         data_files = [
             u
             for u in updates
@@ -699,4 +782,10 @@ class MultigridController:
             "increment_data_count": len(data_files),
             "data_bytes": sum(f.file_size for f in data_files),
         }
-        capture_post(url=url, json=data)
+        capture_post(
+            base_url=str(self._environment.url.geturl()),
+            router_name="prometheus.router",
+            function_name="increment_rsync_transferred_files",
+            visit_name=self._environment.visit,
+            data=data,
+        )

--- a/src/murfey/server/api/file_io_instrument.py
+++ b/src/murfey/server/api/file_io_instrument.py
@@ -34,7 +34,7 @@ class SuggestedPathParameters(BaseModel):
     extra_directory: str = ""
 
 
-@router.post("/visits/{visit_name}/{session_id}/suggested_path")
+@router.post("/visits/{visit_name}/sessions/{session_id}/suggested_path")
 def suggest_path(
     visit_name: str, session_id: int, params: SuggestedPathParameters, db=murfey_db
 ):
@@ -125,7 +125,7 @@ class FractionationParameters(BaseModel):
     fractionation_file_name: str = "eer_fractionation.txt"
 
 
-@router.post("/visits/{visit_name}/{session_id}/eer_fractionation_file")
+@router.post("/visits/{visit_name}/sessions/{session_id}/eer_fractionation_file")
 async def write_eer_fractionation_file(
     visit_name: str,
     session_id: int,

--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -353,7 +353,7 @@ async def request_gain_reference_upload(
     return data
 
 
-@router.post("/visits/{visit_name}/{session_id}/upstream_tiff_data_request")
+@router.post("/visits/{visit_name}/sessions/{session_id}/upstream_tiff_data_request")
 async def request_upstream_tiff_data_download(
     visit_name: str, session_id: MurfeySessionID, db=murfey_db
 ):

--- a/src/murfey/server/api/session_control.py
+++ b/src/murfey/server/api/session_control.py
@@ -285,19 +285,19 @@ def register_restarted_rsyncer(
 
 
 @router.delete("/sessions/{session_id}/rsyncer")
-def delete_rsyncer(session_id: int, source: Path, db=murfey_db):
+def delete_rsyncer(session_id: int, rsyncer_source: StringOfPathModel, db=murfey_db):
     try:
         rsync_instance = db.exec(
             select(RsyncInstance)
             .where(RsyncInstance.session_id == session_id)
-            .where(RsyncInstance.source == str(source))
+            .where(RsyncInstance.source == str(rsyncer_source.path))
         ).one()
         db.delete(rsync_instance)
         db.commit()
     except Exception:
         logger.error(
-            f"Failed to delete rsyncer for source directory {sanitise(str(source))!r} "
-            f"in session {session_id}.",
+            "Failed to delete rsyncer for source directory "
+            f"{sanitise(str(rsyncer_source.path))!r} in session {session_id}.",
             exc_info=True,
         )
 

--- a/src/murfey/server/api/session_control.py
+++ b/src/murfey/server/api/session_control.py
@@ -296,8 +296,8 @@ def delete_rsyncer(session_id: int, rsyncer_source: StringOfPathModel, db=murfey
         db.commit()
     except Exception:
         logger.error(
-            "Failed to delete rsyncer for source directory "
-            f"{sanitise(str(rsyncer_source.path))!r} in session {session_id}.",
+            f"Failed to delete rsyncer for source directory {sanitise(str(rsyncer_source.path))!r} "
+            f"in session {session_id}.",
             exc_info=True,
         )
 

--- a/src/murfey/server/api/session_control.py
+++ b/src/murfey/server/api/session_control.py
@@ -424,7 +424,9 @@ async def find_upstream_visits(session_id: MurfeySessionID, db=murfey_db):
     return upstream_visits
 
 
-@correlative_router.get("/visits/{visit_name}/{session_id}/upstream_tiff_paths")
+@correlative_router.get(
+    "/visits/{visit_name}/sessions/{session_id}/upstream_tiff_paths"
+)
 async def gather_upstream_tiffs(visit_name: str, session_id: int, db=murfey_db):
     """
     Looks for TIFF files associated with the current session in the permitted storage
@@ -446,7 +448,7 @@ async def gather_upstream_tiffs(visit_name: str, session_id: int, db=murfey_db):
 
 
 @correlative_router.get(
-    "/visits/{visit_name}/{session_id}/upstream_tiff/{tiff_path:path}"
+    "/visits/{visit_name}/sessions/{session_id}/upstream_tiff/{tiff_path:path}"
 )
 async def get_tiff(visit_name: str, session_id: int, tiff_path: str, db=murfey_db):
     instrument_name = (

--- a/src/murfey/server/api/session_info.py
+++ b/src/murfey/server/api/session_info.py
@@ -135,7 +135,7 @@ class SessionClients(BaseModel):
     clients: List[ClientEnvironment]
 
 
-@router.get("/session/{session_id}")
+@router.get("/sessions/{session_id}")
 async def get_session(session_id: MurfeySessionID, db=murfey_db) -> SessionClients:
     session = db.exec(select(Session).where(Session.id == session_id)).one()
     clients = db.exec(
@@ -419,7 +419,9 @@ async def find_upstream_visits(session_id: MurfeySessionID, db=murfey_db):
     return upstream_visits
 
 
-@correlative_router.get("/visits/{visit_name}/{session_id}/upstream_tiff_paths")
+@correlative_router.get(
+    "/visits/{visit_name}/sessions/{session_id}/upstream_tiff_paths"
+)
 async def gather_upstream_tiffs(visit_name: str, session_id: int, db=murfey_db):
     """
     Looks for TIFF files associated with the current session in the permitted storage
@@ -441,7 +443,7 @@ async def gather_upstream_tiffs(visit_name: str, session_id: int, db=murfey_db):
 
 
 @correlative_router.get(
-    "/visits/{visit_name}/{session_id}/upstream_tiff/{tiff_path:path}"
+    "/visits/{visit_name}/sessions/{session_id}/upstream_tiff/{tiff_path:path}"
 )
 async def get_tiff(visit_name: str, session_id: int, tiff_path: str, db=murfey_db):
     instrument_name = (

--- a/src/murfey/server/api/workflow.py
+++ b/src/murfey/server/api/workflow.py
@@ -90,7 +90,9 @@ class DCGroupParameters(BaseModel):
     atlas_pixel_size: float = 0
 
 
-@router.post("/visits/{visit_name}/{session_id}/register_data_collection_group")
+@router.post(
+    "/visits/{visit_name}/sessions/{session_id}/register_data_collection_group"
+)
 def register_dc_group(
     visit_name, session_id: MurfeySessionID, dcg_params: DCGroupParameters, db=murfey_db
 ):
@@ -197,7 +199,7 @@ class DCParameters(BaseModel):
     data_collection_tag: str = ""
 
 
-@router.post("/visits/{visit_name}/{session_id}/start_data_collection")
+@router.post("/visits/{visit_name}/sessions/{session_id}/start_data_collection")
 def start_dc(
     visit_name, session_id: MurfeySessionID, dc_params: DCParameters, db=murfey_db
 ):
@@ -263,7 +265,7 @@ class ProcessingJobParameters(BaseModel):
     experiment_type: str = "spa"
 
 
-@router.post("/visits/{visit_name}/{session_id}/register_processing_job")
+@router.post("/visits/{visit_name}/sessions/{session_id}/register_processing_job")
 def register_proc(
     visit_name: str,
     session_id: MurfeySessionID,
@@ -346,7 +348,7 @@ class Tag(BaseModel):
     tag: str
 
 
-@spa_router.post("/visits/{visit_name}/{session_id}/flush_spa_processing")
+@spa_router.post("/visits/{visit_name}/sessions/{session_id}/flush_spa_processing")
 def flush_spa_processing(
     visit_name: str, session_id: MurfeySessionID, tag: Tag, db=murfey_db
 ):
@@ -378,7 +380,7 @@ class SPAProcessFile(BaseModel):
     source: str = ""
 
 
-@spa_router.post("/visits/{visit_name}/{session_id}/spa_preprocess")
+@spa_router.post("/visits/{visit_name}/sessions/{session_id}/spa_preprocess")
 async def request_spa_preprocessing(
     visit_name: str,
     session_id: MurfeySessionID,
@@ -553,7 +555,9 @@ class Source(BaseModel):
     rsync_source: str
 
 
-@tomo_router.post("/visits/{visit_name}/{session_id}/flush_tomography_processing")
+@tomo_router.post(
+    "/visits/{visit_name}/sessions/{session_id}/flush_tomography_processing"
+)
 def flush_tomography_processing(
     visit_name: str, session_id: MurfeySessionID, rsync_source: Source, db=murfey_db
 ):
@@ -638,7 +642,7 @@ class TomoProcessFile(BaseModel):
     group_tag: Optional[str] = None
 
 
-@tomo_router.post("/visits/{visit_name}/{session_id}/tomography_preprocess")
+@tomo_router.post("/visits/{visit_name}/sessions/{session_id}/tomography_preprocess")
 async def request_tomography_preprocessing(
     visit_name: str,
     session_id: MurfeySessionID,
@@ -741,7 +745,7 @@ async def request_tomography_preprocessing(
     return proc_file
 
 
-@tomo_router.post("/visits/{visit_name}/{session_id}/completed_tilt_series")
+@tomo_router.post("/visits/{visit_name}/sesisons{session_id}/completed_tilt_series")
 def register_completed_tilt_series(
     visit_name: str,
     session_id: MurfeySessionID,
@@ -872,7 +876,7 @@ class TiltInfo(BaseModel):
     source: str
 
 
-@tomo_router.post("/visits/{visit_name}/{session_id}/tilt")
+@tomo_router.post("/visits/{visit_name}/sessions{session_id}/tilt")
 async def register_tilt(
     visit_name: str, session_id: MurfeySessionID, tilt_info: TiltInfo, db=murfey_db
 ):
@@ -1006,7 +1010,9 @@ class MillingParameters(BaseModel):
     raw_directory: str
 
 
-@correlative_router.post("/visits/{year}/{visit_name}/{session_id}/make_milling_gif")
+@correlative_router.post(
+    "/year/{year}/visits/{visit_name}/sessions/{session_id}/make_milling_gif"
+)
 async def make_gif(
     year: int,
     visit_name: str,

--- a/src/murfey/server/api/workflow.py
+++ b/src/murfey/server/api/workflow.py
@@ -745,7 +745,7 @@ async def request_tomography_preprocessing(
     return proc_file
 
 
-@tomo_router.post("/visits/{visit_name}/sesisons{session_id}/completed_tilt_series")
+@tomo_router.post("/visits/{visit_name}/sessions/{session_id}/completed_tilt_series")
 def register_completed_tilt_series(
     visit_name: str,
     session_id: MurfeySessionID,
@@ -876,7 +876,7 @@ class TiltInfo(BaseModel):
     source: str
 
 
-@tomo_router.post("/visits/{visit_name}/sessions{session_id}/tilt")
+@tomo_router.post("/visits/{visit_name}/sessions/{session_id}/tilt")
 async def register_tilt(
     visit_name: str, session_id: MurfeySessionID, tilt_info: TiltInfo, db=murfey_db
 ):

--- a/src/murfey/util/client.py
+++ b/src/murfey/util/client.py
@@ -76,7 +76,7 @@ def authorised_requests() -> tuple[Callable, Callable, Callable, Callable]:
 requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
-def capture_post(url: str, json: Union[dict, list] = {}) -> Optional[requests.Response]:
+def capture_post(url: str, json: Union[dict, list] = {}) -> requests.Response:
     try:
         response = requests.post(url, json=json)
     except Exception as e:
@@ -113,13 +113,13 @@ def capture_post(url: str, json: Union[dict, list] = {}) -> Optional[requests.Re
     return response
 
 
-def capture_get(url: str) -> Optional[requests.Response]:
+def capture_get(url: str) -> requests.Response:
     try:
         response = requests.get(url)
     except Exception as e:
         logger.error(f"Exception encountered in get from {url}: {e}")
-        response = None
-    if response and response.status_code != 200:
+        response = requests.Response()
+    if response.status_code != 200:
         logger.warning(
             f"Response to get from {url} had status code {response.status_code}. "
             f"The reason given was {response.reason}"
@@ -127,12 +127,12 @@ def capture_get(url: str) -> Optional[requests.Response]:
     return response
 
 
-def capture_delete(url: str) -> Optional[requests.Response]:
+def capture_delete(url: str) -> requests.Response:
     try:
         response = requests.delete(url)
     except Exception as e:
         logger.error(f"Exception encountered in delete of {url}: {e}")
-        response = None
+        response = requests.Response()
     if response and response.status_code != 200:
         logger.warning(
             f"Response to delete of {url} had status code {response.status_code}. "

--- a/src/murfey/util/client.py
+++ b/src/murfey/util/client.py
@@ -17,7 +17,6 @@ import shutil
 from functools import lru_cache, partial
 from pathlib import Path
 from typing import Awaitable, Callable, Optional, Union
-from urllib.parse import urlparse, urlunparse
 
 import requests
 
@@ -76,9 +75,16 @@ def authorised_requests() -> tuple[Callable, Callable, Callable, Callable]:
 requests.get, requests.post, requests.put, requests.delete = authorised_requests()
 
 
-def capture_post(url: str, json: Union[dict, list] = {}) -> requests.Response:
+def capture_post(
+    base_url: str,
+    router_name: str,
+    function_name: str,
+    data: Optional[dict] = None,
+    **kwargs,
+) -> requests.Response:
+    url = f"{base_url}{url_path_for(router_name, function_name, **kwargs)}"
     try:
-        response = requests.post(url, json=json)
+        response = requests.post(url, json=data)
     except Exception as e:
         logger.error(f"Exception encountered in post to {url}: {e}")
         response = requests.Response()
@@ -87,20 +93,22 @@ def capture_post(url: str, json: Union[dict, list] = {}) -> requests.Response:
             f"Response to post to {url} with data {json} had status code "
             f"{response.status_code}. The reason given was {response.reason}"
         )
-        split_url = urlparse(url)
         client_config = read_config()
-        failure_url = urlunparse(
-            split_url._replace(
-                path=url_path_for(
-                    "session_control.router",
-                    "failed_client_post",
-                    instrument_name=client_config["Murfey"]["instrument_name"],
-                )
-            )
+        failure_address = url_path_for(
+            "session_control.router",
+            "failed_client_post",
+            instrument_name=client_config["Murfey"]["instrument_name"],
         )
+        failure_url = f"{base_url}{failure_address}"
         try:
             resend_response = requests.post(
-                failure_url, json={"url": url, "data": json}
+                failure_url,
+                json={
+                    "router_name": router_name,
+                    "function_name": function_name,
+                    "data": data,
+                    "kwargs": kwargs,
+                },
             )
         except Exception as e:
             logger.error(f"Exception encountered in post to {failure_url}: {e}")
@@ -113,7 +121,10 @@ def capture_post(url: str, json: Union[dict, list] = {}) -> requests.Response:
     return response
 
 
-def capture_get(url: str) -> requests.Response:
+def capture_get(
+    base_url: str, router_name: str, function_name: str, **kwargs
+) -> requests.Response:
+    url = f"{base_url}{url_path_for(router_name, function_name, **kwargs)}"
     try:
         response = requests.get(url)
     except Exception as e:
@@ -127,7 +138,10 @@ def capture_get(url: str) -> requests.Response:
     return response
 
 
-def capture_delete(url: str) -> requests.Response:
+def capture_delete(
+    base_url: str, router_name: str, function_name: str, **kwargs
+) -> requests.Response:
+    url = f"{base_url}{url_path_for(router_name, function_name, **kwargs)}"
     try:
         response = requests.delete(url)
     except Exception as e:
@@ -135,7 +149,7 @@ def capture_delete(url: str) -> requests.Response:
         response = requests.Response()
     if response and response.status_code != 200:
         logger.warning(
-            f"Response to delete of {url} had status code {response.status_code}. "
+            f"Response to delete on {url} had status code {response.status_code}. "
             f"The reason given was {response.reason}"
         )
     return response

--- a/src/murfey/util/route_manifest.yaml
+++ b/src/murfey/util/route_manifest.yaml
@@ -436,7 +436,7 @@ murfey.server.api.file_io_frontend.router:
     methods:
       - POST
 murfey.server.api.file_io_instrument.router:
-  - path: /file_io/instrument/visits/{visit_name}/{session_id}/suggested_path
+  - path: /file_io/instrument/visits/{visit_name}/sessions/{session_id}/suggested_path
     function: suggest_path
     path_params:
       - name: visit_name
@@ -457,7 +457,7 @@ murfey.server.api.file_io_instrument.router:
     path_params: []
     methods:
       - POST
-  - path: /file_io/instrument/visits/{visit_name}/{session_id}/eer_fractionation_file
+  - path: /file_io/instrument/visits/{visit_name}/sessions/{session_id}/eer_fractionation_file
     function: write_eer_fractionation_file
     path_params:
       - name: visit_name
@@ -542,7 +542,7 @@ murfey.server.api.instrument.router:
     path_params: []
     methods:
       - POST
-  - path: /instrument_server/visits/{visit_name}/{session_id}/upstream_tiff_data_request
+  - path: /instrument_server/visits/{visit_name}/sessions/{session_id}/upstream_tiff_data_request
     function: request_upstream_tiff_data_download
     path_params:
       - name: visit_name
@@ -671,7 +671,7 @@ murfey.server.api.session_control.correlative_router:
     path_params: []
     methods:
       - GET
-  - path: /session_control/correlative/visits/{visit_name}/{session_id}/upstream_tiff_paths
+  - path: /session_control/correlative/visits/{visit_name}/sessions/{session_id}/upstream_tiff_paths
     function: gather_upstream_tiffs
     path_params:
       - name: visit_name
@@ -680,7 +680,7 @@ murfey.server.api.session_control.correlative_router:
         type: int
     methods:
       - GET
-  - path: /session_control/correlative/visits/{visit_name}/{session_id}/upstream_tiff/{tiff_path:path}
+  - path: /session_control/correlative/visits/{visit_name}/sessions/{session_id}/upstream_tiff/{tiff_path:path}
     function: get_tiff
     path_params:
       - name: visit_name
@@ -861,7 +861,7 @@ murfey.server.api.session_info.correlative_router:
     path_params: []
     methods:
       - GET
-  - path: /session_info/correlative/visits/{visit_name}/{session_id}/upstream_tiff_paths
+  - path: /session_info/correlative/visits/{visit_name}/sessions/{session_id}/upstream_tiff_paths
     function: gather_upstream_tiffs
     path_params:
       - name: visit_name
@@ -870,7 +870,7 @@ murfey.server.api.session_info.correlative_router:
         type: int
     methods:
       - GET
-  - path: /session_info/correlative/visits/{visit_name}/{session_id}/upstream_tiff/{tiff_path:path}
+  - path: /session_info/correlative/visits/{visit_name}/sessions/{session_id}/upstream_tiff/{tiff_path:path}
     function: get_tiff
     path_params:
       - name: visit_name
@@ -918,7 +918,7 @@ murfey.server.api.session_info.router:
     path_params: []
     methods:
       - GET
-  - path: /session_info/session/{session_id}
+  - path: /session_info/sessions/{session_id}
     function: get_session
     path_params: []
     methods:
@@ -1105,7 +1105,7 @@ murfey.server.api.workflow.correlative_router:
         type: str
     methods:
       - POST
-  - path: /workflow/correlative/visits/{year}/{visit_name}/{session_id}/make_milling_gif
+  - path: /workflow/correlative/year/{year}/visits/{visit_name}/sessions/{session_id}/make_milling_gif
     function: make_gif
     path_params:
       - name: year
@@ -1117,21 +1117,21 @@ murfey.server.api.workflow.correlative_router:
     methods:
       - POST
 murfey.server.api.workflow.router:
-  - path: /workflow/visits/{visit_name}/{session_id}/register_data_collection_group
+  - path: /workflow/visits/{visit_name}/sessions/{session_id}/register_data_collection_group
     function: register_dc_group
     path_params:
       - name: visit_name
         type: typing.Any
     methods:
       - POST
-  - path: /workflow/visits/{visit_name}/{session_id}/start_data_collection
+  - path: /workflow/visits/{visit_name}/sessions/{session_id}/start_data_collection
     function: start_dc
     path_params:
       - name: visit_name
         type: typing.Any
     methods:
       - POST
-  - path: /workflow/visits/{visit_name}/{session_id}/register_processing_job
+  - path: /workflow/visits/{visit_name}/sessions/{session_id}/register_processing_job
     function: register_proc
     path_params:
       - name: visit_name
@@ -1144,14 +1144,14 @@ murfey.server.api.workflow.spa_router:
     path_params: []
     methods:
       - POST
-  - path: /workflow/spa/visits/{visit_name}/{session_id}/flush_spa_processing
+  - path: /workflow/spa/visits/{visit_name}/sessions/{session_id}/flush_spa_processing
     function: flush_spa_processing
     path_params:
       - name: visit_name
         type: str
     methods:
       - POST
-  - path: /workflow/spa/visits/{visit_name}/{session_id}/spa_preprocess
+  - path: /workflow/spa/visits/{visit_name}/sessions/{session_id}/spa_preprocess
     function: request_spa_preprocessing
     path_params:
       - name: visit_name
@@ -1164,7 +1164,7 @@ murfey.server.api.workflow.tomo_router:
     path_params: []
     methods:
       - POST
-  - path: /workflow/tomo/visits/{visit_name}/{session_id}/flush_tomography_processing
+  - path: /workflow/tomo/visits/{visit_name}/sessions/{session_id}/flush_tomography_processing
     function: flush_tomography_processing
     path_params:
       - name: visit_name
@@ -1185,14 +1185,14 @@ murfey.server.api.workflow.tomo_router:
         type: int
     methods:
       - POST
-  - path: /workflow/tomo/visits/{visit_name}/{session_id}/tomography_preprocess
+  - path: /workflow/tomo/visits/{visit_name}/sessions/{session_id}/tomography_preprocess
     function: request_tomography_preprocessing
     path_params:
       - name: visit_name
         type: str
     methods:
       - POST
-  - path: /workflow/tomo/visits/{visit_name}/{session_id}/completed_tilt_series
+  - path: /workflow/tomo/visits/{visit_name}/sessions/{session_id}/completed_tilt_series
     function: register_completed_tilt_series
     path_params:
       - name: visit_name
@@ -1206,7 +1206,7 @@ murfey.server.api.workflow.tomo_router:
         type: str
     methods:
       - POST
-  - path: /workflow/tomo/visits/{visit_name}/{session_id}/tilt
+  - path: /workflow/tomo/visits/{visit_name}/sessions/{session_id}/tilt
     function: register_tilt
     path_params:
       - name: visit_name

--- a/tests/client/tui/test_main.py
+++ b/tests/client/tui/test_main.py
@@ -17,9 +17,9 @@ test_get_visit_list_params_matrix = (
 
 
 @pytest.mark.parametrize("test_params", test_get_visit_list_params_matrix)
-@mock.patch("murfey.client.tui.main.requests")
+@mock.patch("murfey.client.tui.main.capture_get")
 def test_get_visit_list(
-    mock_request,
+    mock_request_get,
     test_params: tuple[str],
     mock_client_configuration,
 ):
@@ -49,17 +49,19 @@ def test_get_visit_list(
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = example_visits
-    mock_request.get.return_value = mock_response
+    mock_request_get.return_value = mock_response
 
     # read_config() has to be patched using fixture, so has to be done in function
     with mock.patch("murfey.util.client.read_config", mock_client_configuration):
         visits = _get_visit_list(urlparse(server_url), instrument_name)
 
     # Check that request was sent with the correct URL
-    expected_url = (
-        f"{server_url}/session_control/instruments/{instrument_name}/visits_raw"
+    mock_request_get.assert_called_once_with(
+        base_url=server_url,
+        router_name="session_control.router",
+        function_name="get_current_visits",
+        instrument_name=instrument_name,
     )
-    mock_request.get.assert_called_once_with(expected_url)
 
     # Check that expected outputs are correct (order-sensitive)
     for v, visit in enumerate(visits):


### PR DESCRIPTION
This updates the `capture_post/get/delete` calls to take in the router name and function instead of a url. The url is then constructed.
By doing this any failed calls can send the function name on for reuse.