### PR TITLE
Various router and auth fixes

### DIFF
--- a/src/murfey/client/contexts/spa.py
+++ b/src/murfey/client/contexts/spa.py
@@ -302,7 +302,7 @@ class SPAModularContext(Context):
             data_collection_group = (
                 capture_get(
                     base_url=str(environment.url.geturl()),
-                    router_name="session_info.router",
+                    router_name="session_control.router",
                     function_name="get_dc_groups",
                     token=self._token,
                     session_id=environment.murfey_session,

--- a/src/murfey/client/destinations.py
+++ b/src/murfey/client/destinations.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict
+
+from murfey.client.analyser import Analyser
+from murfey.client.instance_environment import (
+    MurfeyInstanceEnvironment,
+    global_env_lock,
+)
+from murfey.util.client import capture_get, capture_post
+
+logger = logging.getLogger("murfey.client.destinations")
+
+
+def determine_default_destination(
+    visit: str,
+    source: Path,
+    destination: str,
+    environment: MurfeyInstanceEnvironment,
+    analysers: Dict[Path, Analyser],
+    token: str,
+    touch: bool = False,
+    extra_directory: str = "",
+    include_mid_path: bool = True,
+    use_suggested_path: bool = True,
+) -> str:
+    machine_data = capture_get(
+        base_url=str(environment.url.geturl()),
+        router_name="session_control.router",
+        function_name="machine_info_by_instrument",
+        token=token,
+        instrument_name=environment.instrument_name,
+    ).json()
+    _default = ""
+    if environment.processing_only_mode and environment.sources:
+        logger.info(f"Processing only mode with sources {environment.sources}")
+        _default = str(environment.sources[0].absolute()) or str(Path.cwd())
+    elif machine_data.get("data_directories"):
+        for data_dir in machine_data["data_directories"]:
+            if source.absolute() == Path(data_dir).absolute():
+                _default = f"{destination}/{visit}"
+                break
+            else:
+                try:
+                    mid_path = source.absolute().relative_to(Path(data_dir).absolute())
+                    if use_suggested_path:
+                        with global_env_lock:
+                            source_name = (
+                                source.name
+                                if source.name != "Images-Disc1"
+                                else source.parent.name
+                            )
+                            if environment.destination_registry.get(source_name):
+                                _default = environment.destination_registry[source_name]
+                            else:
+                                suggested_path_response = capture_post(
+                                    base_url=str(environment.url.geturl()),
+                                    router_name="file_io_instrument.router",
+                                    function_name="suggest_path",
+                                    token=token,
+                                    visit_name=visit,
+                                    session_id=environment.murfey_session,
+                                    data={
+                                        "base_path": f"{destination}/{visit}/{mid_path.parent if include_mid_path else ''}/raw",
+                                        "touch": touch,
+                                        "extra_directory": extra_directory,
+                                    },
+                                )
+                                if suggested_path_response is None:
+                                    raise RuntimeError("Murfey server is unreachable")
+                                _default = suggested_path_response.json().get(
+                                    "suggested_path"
+                                )
+                                environment.destination_registry[source_name] = _default
+                    else:
+                        _default = f"{destination}/{visit}/{mid_path if include_mid_path else source.name}"
+                    break
+                except (ValueError, KeyError):
+                    _default = ""
+        else:
+            _default = ""
+    else:
+        _default = f"{destination}/{visit}"
+    return (
+        _default + f"/{extra_directory}"
+        if not _default.endswith("/")
+        else _default + f"{extra_directory}"
+    )

--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -14,9 +14,9 @@ import murfey.client.websocket
 from murfey.client.analyser import Analyser
 from murfey.client.contexts.spa import SPAModularContext
 from murfey.client.contexts.tomo import TomographyContext
+from murfey.client.destinations import determine_default_destination
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
 from murfey.client.rsync import RSyncer, RSyncerUpdate, TransferResult
-from murfey.client.tui.screens import determine_default_destination
 from murfey.client.watchdir import DirWatcher
 from murfey.util import posix_path
 from murfey.util.client import (
@@ -267,6 +267,7 @@ class MultigridController:
                     self._environment.default_destinations[source],
                     self._environment,
                     self.analysers or {},
+                    self.token,
                     touch=True,
                     extra_directory=extra_directory,
                     include_mid_path=include_mid_path,

--- a/src/murfey/client/tui/app.py
+++ b/src/murfey/client/tui/app.py
@@ -16,6 +16,7 @@ from textual.widgets import Button, Input
 from murfey.client.analyser import Analyser
 from murfey.client.contexts.spa import SPAModularContext
 from murfey.client.contexts.tomo import TomographyContext
+from murfey.client.destinations import determine_default_destination
 from murfey.client.instance_environment import MurfeyInstanceEnvironment
 from murfey.client.rsync import RSyncer, RSyncerUpdate, TransferResult
 from murfey.client.tui.screens import (
@@ -27,7 +28,6 @@ from murfey.client.tui.screens import (
     VisitCreation,
     VisitSelection,
     WaitingScreen,
-    determine_default_destination,
 )
 from murfey.client.tui.status_bar import StatusBar
 from murfey.client.watchdir import DirWatcher
@@ -177,6 +177,7 @@ class MurfeyTUI(App):
                     self._default_destinations[source],
                     self._environment,
                     self.analysers,
+                    token,
                     touch=True,
                     extra_directory=extra_directory,
                     include_mid_path=include_mid_path,

--- a/src/murfey/client/tui/screens.py
+++ b/src/murfey/client/tui/screens.py
@@ -45,14 +45,10 @@ from textual.widgets import (
 )
 from werkzeug.utils import secure_filename
 
-from murfey.client.analyser import Analyser
 from murfey.client.contexts.spa import SPAModularContext
 from murfey.client.contexts.tomo import TomographyContext
+from murfey.client.destinations import determine_default_destination
 from murfey.client.gain_ref import determine_gain_ref
-from murfey.client.instance_environment import (
-    MurfeyInstanceEnvironment,
-    global_env_lock,
-)
 from murfey.client.rsync import RSyncer
 from murfey.util import posix_path
 from murfey.util.client import (
@@ -70,81 +66,6 @@ ReactiveType = TypeVar("ReactiveType")
 
 token = read_config()["Murfey"].get("token", "")
 instrument_name = read_config()["Murfey"].get("instrument_name", "")
-
-
-def determine_default_destination(
-    visit: str,
-    source: Path,
-    destination: str,
-    environment: MurfeyInstanceEnvironment,
-    analysers: Dict[Path, Analyser],
-    touch: bool = False,
-    extra_directory: str = "",
-    include_mid_path: bool = True,
-    use_suggested_path: bool = True,
-) -> str:
-    machine_data = capture_get(
-        base_url=str(environment.url.geturl()),
-        router_name="session_control.router",
-        function_name="machine_info_by_instrument",
-        token=token,
-        instrument_name=environment.instrument_name,
-    ).json()
-    _default = ""
-    if environment.processing_only_mode and environment.sources:
-        log.info(f"Processing only mode with sources {environment.sources}")
-        _default = str(environment.sources[0].absolute()) or str(Path.cwd())
-    elif machine_data.get("data_directories"):
-        for data_dir in machine_data["data_directories"]:
-            if source.absolute() == Path(data_dir).absolute():
-                _default = f"{destination}/{visit}"
-                break
-            else:
-                try:
-                    mid_path = source.absolute().relative_to(Path(data_dir).absolute())
-                    if use_suggested_path:
-                        with global_env_lock:
-                            source_name = (
-                                source.name
-                                if source.name != "Images-Disc1"
-                                else source.parent.name
-                            )
-                            if environment.destination_registry.get(source_name):
-                                _default = environment.destination_registry[source_name]
-                            else:
-                                suggested_path_response = capture_post(
-                                    base_url=str(environment.url.geturl()),
-                                    router_name="file_io_instrument.router",
-                                    function_name="suggest_path",
-                                    token=token,
-                                    visit_name=visit,
-                                    session_id=environment.murfey_session,
-                                    data={
-                                        "base_path": f"{destination}/{visit}/{mid_path.parent if include_mid_path else ''}/raw",
-                                        "touch": touch,
-                                        "extra_directory": extra_directory,
-                                    },
-                                )
-                                if suggested_path_response is None:
-                                    raise RuntimeError("Murfey server is unreachable")
-                                _default = suggested_path_response.json().get(
-                                    "suggested_path"
-                                )
-                                environment.destination_registry[source_name] = _default
-                    else:
-                        _default = f"{destination}/{visit}/{mid_path if include_mid_path else source.name}"
-                    break
-                except (ValueError, KeyError):
-                    _default = ""
-        else:
-            _default = ""
-    else:
-        _default = f"{destination}/{visit}"
-    return (
-        _default + f"/{extra_directory}"
-        if not _default.endswith("/")
-        else _default + f"{extra_directory}"
-    )
 
 
 class InputResponse(NamedTuple):
@@ -349,6 +270,7 @@ class LaunchScreen(Screen):
                     defd,
                     self.app._environment,
                     self.app.analysers,
+                    token,
                     touch=True,
                 )
                 visit_path = defd + f"/{text}"
@@ -1077,6 +999,7 @@ class DestinationSelect(Screen):
                                 f"{datetime.now().year}",
                                 self.app._environment,
                                 self.app.analysers,
+                                token,
                                 touch=True,
                             )
                             if dest and dest in destinations:

--- a/src/murfey/server/api/session_control.py
+++ b/src/murfey/server/api/session_control.py
@@ -206,16 +206,20 @@ def count_number_of_movies(db=murfey_db) -> Dict[str, int]:
 
 
 class PostInfo(BaseModel):
-    url: str
+    router_name: str
+    function_name: str
     data: dict
+    kwargs: dict
 
 
 @router.post("/instruments/{instrument_name}/failed_client_post")
 def failed_client_post(instrument_name: str, post_info: PostInfo):
     zocalo_message = {
         "register": "failed_client_post",
-        "url": post_info.url,
-        "json": post_info.data,
+        "router_name": post_info.router_name,
+        "function_name": post_info.function_name,
+        "data": post_info.data,
+        "kwargs": post_info.kwargs,
     }
     if _transport_object:
         _transport_object.send(_transport_object.feedback_queue, zocalo_message)

--- a/src/murfey/server/api/session_control.py
+++ b/src/murfey/server/api/session_control.py
@@ -165,6 +165,16 @@ def remove_session(session_id: MurfeySessionID, db=murfey_db):
     remove_session_by_id(session_id, db)
 
 
+@router.get("/sessions/{session_id}/data_collection_groups")
+def get_dc_groups(
+    session_id: MurfeySessionID, db=murfey_db
+) -> Dict[str, DataCollectionGroup]:
+    data_collection_groups = db.exec(
+        select(DataCollectionGroup).where(DataCollectionGroup.session_id == session_id)
+    ).all()
+    return {dcg.tag: dcg for dcg in data_collection_groups}
+
+
 @router.post("/sessions/{session_id}/successful_processing")
 def register_processing_success_in_ispyb(
     session_id: MurfeySessionID, db=ispyb_db, murfey_db=murfey_db

--- a/src/murfey/util/client.py
+++ b/src/murfey/util/client.py
@@ -85,7 +85,7 @@ def capture_post(
         response = requests.Response()
     if response.status_code != 200:
         logger.warning(
-            f"Response to post to {url} with data {json} had status code "
+            f"Response to post to {url} with data {data} had status code "
             f"{response.status_code}. The reason given was {response.reason}"
         )
         client_config = read_config()

--- a/src/murfey/util/route_manifest.yaml
+++ b/src/murfey/util/route_manifest.yaml
@@ -826,6 +826,13 @@ murfey.server.api.session_control.router:
         type: int
     methods:
       - DELETE
+  - path: /session_info/sessions/{session_id}/data_collection_groups
+    function: get_dc_groups
+    path_params:
+      - name: session_id
+        type: int
+    methods:
+      - GET
   - path: /session_control/sessions/{session_id}/successful_processing
     function: register_processing_success_in_ispyb
     path_params:


### PR DESCRIPTION
- Add data collection groups finding to session_control so it can be accessed by client
- Move the default destination determination to new file and require token in it to avoid defaulting to client token
- Adjust the model for failed posts to match the client
- Fix log on failed posts