### PR TITLE
Fixes for tomo multigrid destinations

### DIFF
--- a/src/murfey/client/destinations.py
+++ b/src/murfey/client/destinations.py
@@ -47,11 +47,12 @@ def determine_default_destination(
                     mid_path = source.absolute().relative_to(Path(data_dir).absolute())
                     if use_suggested_path:
                         with global_env_lock:
-                            source_name = (
-                                source.name
-                                if source.name != "Images-Disc1"
-                                else source.parent.name
-                            )
+                            if source.name == "Images-Disc1":
+                                source_name = source.parent.name
+                            elif source.name.startswith("Sample"):
+                                source_name = f"{source.parent.name}_{source.name}"
+                            else:
+                                source_name = source.name
                             if environment.destination_registry.get(source_name):
                                 _default = environment.destination_registry[source_name]
                             else:

--- a/src/murfey/client/watchdir_multigrid.py
+++ b/src/murfey/client/watchdir_multigrid.py
@@ -51,10 +51,10 @@ class MultigridDirWatcher(Observer):
             self.thread.join()
         log.debug("MultigridDirWatcher thread stop completed")
 
-    def _handle_metadata(self, directory: Path):
+    def _handle_metadata(self, directory: Path, extra_directory: str):
         self.notify(
             directory,
-            extra_directory=f"metadata_{directory.name}",
+            extra_directory=extra_directory,
             include_mid_path=False,
             analyse=self._analyse,
             limited=True,
@@ -130,7 +130,10 @@ class MultigridDirWatcher(Observer):
                         for sample in sample_dirs:
                             if len(list(sample.glob("*.mdoc"))):
                                 if sample not in self._seen_dirs:
-                                    self._handle_metadata(sample)
+                                    self._handle_metadata(
+                                        sample,
+                                        extra_directory=f"metadata_{sample.parent.name}_{sample.name}",
+                                    )
                                 self._handle_fractions(
                                     sample.parent.parent.parent
                                     / f"{sample.parent.name}_{sample.name}",
@@ -139,7 +142,9 @@ class MultigridDirWatcher(Observer):
 
                     else:
                         if d.is_dir() and d not in self._seen_dirs:
-                            self._handle_metadata(d)
+                            self._handle_metadata(
+                                d, extra_directory=f"metadata_{d.name}"
+                            )
                         self._handle_fractions(d.parent.parent / d.name, first_loop)
 
             if first_loop:

--- a/src/murfey/client/watchdir_multigrid.py
+++ b/src/murfey/client/watchdir_multigrid.py
@@ -132,8 +132,8 @@ class MultigridDirWatcher(Observer):
                                 if sample not in self._seen_dirs:
                                     self._handle_metadata(sample)
                                 self._handle_fractions(
-                                    d.parent.parent.parent
-                                    / f"{d.parent.name}_{d.name}",
+                                    sample.parent.parent.parent
+                                    / f"{sample.parent.name}_{sample.name}",
                                     first_loop,
                                 )
 


### PR DESCRIPTION
- Destination should be from sample not d
- Name tomo metadata as `metadata_Supervisor_..._SampleX`
- Match fractions and metadata in the destinations directory