### PR TITLE
When finalising an rsyncer set the end time to now

### DIFF
--- a/src/murfey/client/rsync.py
+++ b/src/murfey/client/rsync.py
@@ -199,6 +199,7 @@ class RSyncer(Observer):
         self.stop()
         self._remove_files = True
         self._notify = False
+        self._end_time = datetime.now()
         if thread:
             self.thread = threading.Thread(
                 name=f"RSync finalisation {self._basepath}:{self._remote}",


### PR DESCRIPTION
Pressing visit complete currently registers files as skipped in some cases. Anything the rsyncer has seen should probably be flushed when doing visit completion.