### PR TITLE
More checks for skipped files on visit end time

### DIFF
--- a/src/murfey/client/multigrid_control.py
+++ b/src/murfey/client/multigrid_control.py
@@ -137,13 +137,17 @@ class MultigridController:
             for w in self._environment.watchers.values():
                 if w.is_safe_to_stop():
                     w.stop()
-            return (
-                all(r._finalised for r in self.rsync_processes.values())
-                and not any(a.thread.is_alive() for a in self.analysers.values())
-                and not any(
-                    w.thread.is_alive() for w in self._environment.watchers.values()
-                )
+            rsyncers_finalised = all(
+                r._finalised for r in self.rsync_processes.values()
             )
+            analysers_alive = any(a.thread.is_alive() for a in self.analysers.values())
+            watchers_alive = any(
+                w.thread.is_alive() for w in self._environment.watchers.values()
+            )
+            log.debug(
+                f"Dormancy check: rsyncers {rsyncers_finalised}, analysers {not analysers_alive}, watchers {not watchers_alive}"
+            )
+            return rsyncers_finalised and not analysers_alive and not watchers_alive
         log.debug(f"Multigrid watcher for session {self.session_id} is still active")
         return False
 

--- a/src/murfey/client/rsync.py
+++ b/src/murfey/client/rsync.py
@@ -79,6 +79,7 @@ class RSyncer(Observer):
         self._notify = notify
         self._finalised = False
         self._end_time = end_time
+        self._finalising = False
 
         self._skipped_files: List[Path] = []
 
@@ -199,7 +200,8 @@ class RSyncer(Observer):
         self.stop()
         self._remove_files = True
         self._notify = False
-        self._end_time = datetime.now()
+        self._end_time = None
+        self._finalising = True
         if thread:
             self.thread = threading.Thread(
                 name=f"RSync finalisation {self._basepath}:{self._remote}",
@@ -330,6 +332,9 @@ class RSyncer(Observer):
             ]
             self._skipped_files.extend(set(infiles).difference(set(files)))
             num_skipped_files = len(set(infiles).difference(set(files)))
+        elif self._finalising:
+            files = [f for f in infiles if f.is_file() and f not in self._skipped_files]
+            num_skipped_files = 0
         else:
             files = [f for f in infiles if f.is_file()]
             num_skipped_files = 0


### PR DESCRIPTION
At visit end, do not check the end time of the files. Instead, if they were not skipped before they should be transferred. If skipped before, ignore them.

Also adds log to determine which bit of the dormancy check is failing.