### PR TITLE
Reset tilt series lengths on repeated tilts, to avoid repeat processing

### DIFF
--- a/src/murfey/client/contexts/tomo.py
+++ b/src/murfey/client/contexts/tomo.py
@@ -267,10 +267,11 @@ class TomographyContext(Context):
                     [str(file_transferred_to), tilt_angle]
                 ]
         if tilt_series in self._completed_tilt_series:
-            logger.info(
+            logger.warning(
                 f"Tilt series {tilt_series} was previously thought complete but now {file_path} has been seen"
             )
             self._completed_tilt_series.remove(tilt_series)
+            self._tilt_series_sizes[tilt_series] = 0
             rerun_data = {
                 "session_id": environment.murfey_session,
                 "tag": tilt_series,

--- a/src/murfey/server/api/workflow.py
+++ b/src/murfey/server/api/workflow.py
@@ -869,6 +869,7 @@ def register_tilt_series_for_rerun(
     ).all()
     for ts in tilt_series_db:
         ts.processing_requested = False
+        ts.tilt_series_length = -1
         db.add(ts)
     db.commit()
 


### PR DESCRIPTION
When a tilt series is cancelled on the microscope, an mdoc gets written and we mark the tilt series as complete.
The current behaviour is then that we process the tomogram and do so again for every newly found tilt.

This PR changes the code to remove knowledge of tilt series length when a new tilt is found (i.e. when length exceeds the number in the mdoc). This then means we will not launch processing again until the mdoc is re-written with the correct length.

Should reduce the number of processing times from ntilts+1 to 2.
Will still need some work on the processing side as the processed star files contain duplicated tomograms.