### PR TITLE
Update the current processing gain when a new one is uploaded

### DIFF
--- a/src/murfey/server/api/session_info.py
+++ b/src/murfey/server/api/session_info.py
@@ -43,6 +43,7 @@ from murfey.util.db import (
     ProcessingJob,
     RsyncInstance,
     Session,
+    SessionProcessingParameters,
     SPAFeedbackParameters,
     SPARelionParameters,
     Tilt,
@@ -257,6 +258,16 @@ def update_current_gain_ref(
     session = db.exec(select(Session).where(Session.id == session_id)).one()
     session.current_gain_ref = new_gain_ref.path
     db.add(session)
+
+    session_processing_parameters = db.exec(
+        select(SessionProcessingParameters).where(
+            SessionProcessingParameters.session_id == session_id
+        )
+    ).all()
+    if session_processing_parameters:
+        session_processing_parameters[0].gain_ref = new_gain_ref.path
+        db.add(session_processing_parameters[0])
+
     db.commit()
 
 


### PR DESCRIPTION
Update both the `Session` and `SessionProcessingParameters` gain references after a new one is uploaded.

When first done, the `SessionProcessingParameters` entry will not exist so this must be checked before trying to update.