### PR TITLE
Raise an exception if no 2D murfey ids present

### DIFF
--- a/src/murfey/server/feedback.py
+++ b/src/murfey/server/feedback.py
@@ -258,6 +258,8 @@ def _3d_class_murfey_ids(particles_file: str, app_id: int, _db) -> Dict[str, int
             and db.Class3D.pj_id == pj_id
         )
     ).all()
+    if not classes:
+        raise ValueError(f"No 3D classification IDs found for {particles_file}")
     return {str(cl.class_number): cl.murfey_id for cl in classes}
 
 


### PR DESCRIPTION
We keep hitting a case where no ids get sent to 2D classification. It's not clear why this happens, but if we don't have ids to send it would be better to just raise an exception in murfey.

Also I've changed the fixed number of 50 ids to the value in the default parameters (which is also 50 currently).