### PR TITLE
Start transfer for all tomo multigrid slots with sessions

### DIFF
--- a/src/murfey/client/analyser.py
+++ b/src/murfey/client/analyser.py
@@ -63,7 +63,9 @@ class Analyser(Observer):
         self._acquisition_software = ""
         self._context: Context | None = None
         self.queue: queue.Queue = queue.Queue()
-        self.thread = threading.Thread(name="Analyser", target=self._analyse_in_thread)
+        self.thread = threading.Thread(
+            name=f"Analyser {basepath_local}", target=self._analyse_in_thread
+        )
         self._stopping = False
         self._halt_thread = False
         self._murfey_config = (

--- a/src/murfey/client/watchdir_multigrid.py
+++ b/src/murfey/client/watchdir_multigrid.py
@@ -110,7 +110,8 @@ class MultigridDirWatcher(Observer):
                     sample_dirs = list(d.glob("Sample*"))
                     if d.is_dir() and len(sample_dirs):
                         for sample in sample_dirs:
-                            if len(list(sample.glob("*.mdoc"))):
+                            if (sample / "Session.dm").is_file():
+                                # Transfer only folders where a tomo session exists
                                 if sample not in self._seen_dirs:
                                     self._handle_metadata(
                                         sample,


### PR DESCRIPTION
Previously we only started tomo multigrid transfer when an mdoc appears. This changes it to start when a Session.dm appears so that all search maps get transferred, but meaning that empty cassette slots do not create a raw.

I also put a name on the analysers as this will help with debugging when we come to attempt the full tomo multigrid changes described in #792 