### PR TITLE
Silence the debug logs notifying about skipped blacklisted files/directories

### DIFF
--- a/src/murfey/client/watchdir.py
+++ b/src/murfey/client/watchdir.py
@@ -250,7 +250,7 @@ class DirWatcher(Observer):
                 pattern in entry.name
                 for pattern in self._substrings_blacklist.get("directories", [])
             ):
-                log.debug(f"Skipping blacklisted directory {str(entry.name)!r}")
+                # log.debug(f"Skipping blacklisted directory {str(entry.name)!r}")
                 continue
             elif entry.is_dir() and (
                 modification_time is None or entry.stat().st_ctime >= modification_time
@@ -265,7 +265,7 @@ class DirWatcher(Observer):
                     pattern in entry.name
                     for pattern in self._substrings_blacklist.get("files", [])
                 ):
-                    log.debug(f"Skipping blacklisted file {str(entry.name)!r}")
+                    # log.debug(f"Skipping blacklisted file {str(entry.name)!r}")
                     continue
                 # Get file statistics and append file to dictionary
                 try:


### PR DESCRIPTION
These happen too frequently when the `DirWatcher` is run as a thread, and end up polluting the log stream we are currently using.