### PR TITLE
Add a config key to allow transfer to a single raw directory

### DIFF
--- a/src/murfey/client/watchdir_multigrid.py
+++ b/src/murfey/client/watchdir_multigrid.py
@@ -49,12 +49,12 @@ class MultigridDirWatcher(Observer):
             self.thread.join()
         log.debug("MultigridDirWatcher thread stop completed")
 
-    def _handle_metadata(self, directory: Path, extra_directory: str):
+    def _handle_metadata(self, directory: Path, extra_directory: str, limited=True):
         self.notify(
             directory,
             extra_directory=extra_directory,
             analyse=self._analyse,
-            limited=True,
+            limited=limited,
             tag="metadata",
         )
         self._seen_dirs.append(directory)
@@ -121,6 +121,12 @@ class MultigridDirWatcher(Observer):
                                     sample.parent.parent.parent
                                     / f"{sample.parent.name}_{sample.name}",
                                 )
+
+                    elif self._machine_config["single_data_directory"]:
+                        if d.is_dir() and d not in self._seen_dirs:
+                            self._handle_metadata(
+                                d, extra_directory=f"{d.name}", limited=False
+                            )
 
                     else:
                         if d.is_dir() and d not in self._seen_dirs:

--- a/src/murfey/client/watchdir_multigrid.py
+++ b/src/murfey/client/watchdir_multigrid.py
@@ -50,6 +50,12 @@ class MultigridDirWatcher(Observer):
         log.debug("MultigridDirWatcher thread stop completed")
 
     def _handle_metadata(self, directory: Path, extra_directory: str, limited=True):
+        """
+        Handles all unknown directories in the visit folder
+        These are transferred into a raw folder as subdirectories
+        named using "extra_directory"
+        For SPA and Tomo this is metadata, for SXT this will be both metadata and data
+        """
         self.notify(
             directory,
             extra_directory=extra_directory,

--- a/src/murfey/server/api/file_io_instrument.py
+++ b/src/murfey/server/api/file_io_instrument.py
@@ -85,15 +85,16 @@ def suggest_path(
             raise FileNotFoundError(log_message)
 
     check_path_name = check_path.name
-    while check_path.exists():
-        count = count + 1 if count else 2
-        check_path = check_path.parent / f"{check_path_name}{count}"
+    if not machine_config.single_data_directory:
+        while check_path.exists():
+            count = count + 1 if count else 2
+            check_path = check_path.parent / f"{check_path_name}{count}"
     if params.touch:
-        check_path.mkdir()
+        check_path.mkdir(exist_ok=True)
         os.chmod(check_path, mode=machine_config.mkdir_chmod)
         if params.extra_directory:
             extra_dir = check_path / secure_filename(params.extra_directory)
-            extra_dir.mkdir()
+            extra_dir.mkdir(exist_ok=True)
             os.chmod(extra_dir, mode=machine_config.mkdir_chmod)
     return {"suggested_path": check_path.relative_to(rsync_basepath)}
 

--- a/src/murfey/util/config.py
+++ b/src/murfey/util/config.py
@@ -50,6 +50,7 @@ class MachineConfig(BaseModel):  # type: ignore
     analyse_created_directories: list[str] = []
     gain_reference_directory: Optional[Path] = None
     eer_fractionation_file_template: str = ""
+    single_data_directory: bool = False
 
     # Data transfer setup -------------------------------------------------------------
     # General setup


### PR DESCRIPTION
One possible option for how to resolve the b24 data transfer where we want everything to go to the same raw folder, but using different rsyncers and analysers.

This adds a config key to override the suggested path logic and return raw each time. It also turns the limited transfer behaviour off in for all rsyncers made by this method so the files are analysed.