### PR TITLE
set alert_end_time for each visit separately

### DIFF
--- a/src/murfey/server/api/instrument.py
+++ b/src/murfey/server/api/instrument.py
@@ -247,11 +247,8 @@ async def update_visit_end_time(
     db.commit()
 
     # Update the alert endtime on prometheus
-    alert_end_time = prom.alert_end_time._value.get()
     if end_time:
-        visit_end_timestamp = end_time.timestamp()
-        if alert_end_time < visit_end_timestamp:
-            prom.alert_end_time.set(visit_end_timestamp)
+        prom.alert_end_time.labels(visit=session_entry.visit).set(end_time.timestamp())
 
     # Update the multigrid controller
     data = {}

--- a/src/murfey/server/api/prometheus.py
+++ b/src/murfey/server/api/prometheus.py
@@ -99,12 +99,6 @@ def increment_rsync_skipped_files_prometheus(
     ).inc(rsyncer_skipped_files.increment_count)
 
 
-@router.post("/visits/{visit_name}/monitoring/{on}")
-def change_monitoring_status(visit_name: str, on: int):
-    prom.monitoring_switch.labels(visit=visit_name)
-    prom.monitoring_switch.labels(visit=visit_name).set(on)
-
-
 @router.get("/metrics/{metric_name}")
 def inspect_prometheus_metrics(
     metric_name: str,

--- a/src/murfey/server/api/session_info.py
+++ b/src/murfey/server/api/session_info.py
@@ -188,11 +188,8 @@ def create_session(
     db.commit()
     sid = s.id
 
-    alert_end_time = prom.alert_end_time._value.get()  # timestamp
     if visit_end_time.end_time:
-        visit_end_timestamp = visit_end_time.end_time.timestamp()
-        if alert_end_time < visit_end_timestamp:
-            prom.alert_end_time.set(visit_end_timestamp)
+        prom.alert_end_time.labels(visit=visit).set(visit_end_time.end_time.timestamp())
 
     return sid
 

--- a/src/murfey/server/api/session_shared.py
+++ b/src/murfey/server/api/session_shared.py
@@ -31,9 +31,9 @@ def remove_session_by_id(session_id: int, db):
     # Don't remove prometheus metrics if there are other sessions using them
     if len(sessions_for_visit) == 1:
         safe_run(
-            prom.monitoring_switch.remove,
+            prom.alert_end_time.remove,
             args=(session.visit,),
-            label="monitoring_switch",
+            label="alert_end_time",
         )
         rsync_instances = db.exec(
             select(RsyncInstance).where(RsyncInstance.session_id == session_id)

--- a/src/murfey/server/prometheus.py
+++ b/src/murfey/server/prometheus.py
@@ -38,10 +38,5 @@ preprocessed_movies = Counter(
 
 exposure_time = Gauge("exposure_time", "Exposure time for a single movie")
 
-monitoring_switch = Gauge(
-    "monitoring_on",
-    "Whether the corresponding visit should be monitored or not",
-    ["visit"],
-)
 
 alert_end_time = Gauge("alert_end_time", "End time for alerts", ["visit"])

--- a/src/murfey/server/prometheus.py
+++ b/src/murfey/server/prometheus.py
@@ -44,4 +44,4 @@ monitoring_switch = Gauge(
     ["visit"],
 )
 
-alert_end_time = Gauge("alert_end_time", "End time for alerts", [])
+alert_end_time = Gauge("alert_end_time", "End time for alerts", ["visit"])

--- a/src/murfey/util/route_manifest.yaml
+++ b/src/murfey/util/route_manifest.yaml
@@ -703,15 +703,6 @@ murfey.server.api.prometheus.router:
         type: str
     methods:
       - POST
-  - path: /prometheus/visits/{visit_name}/monitoring/{on}
-    function: change_monitoring_status
-    path_params:
-      - name: visit_name
-        type: str
-      - name: "on"
-        type: int
-    methods:
-      - POST
   - path: /prometheus/metrics/{metric_name}
     function: inspect_prometheus_metrics
     path_params:


### PR DESCRIPTION
- added "visit" label to alert_end_time so each visit now has a different alert_end_time
    -> therefore don't need to check if new alert_end_time is longer than existing time (when creating or updating visit end time)
- remove alert_end_time for that visit when session removed