### PR TITLE
Updated the 'align_self', 'flatten', and 'align_across' parameters to…

### DIFF
--- a/src/murfey/workflows/clem/register_align_and_merge_results.py
+++ b/src/murfey/workflows/clem/register_align_and_merge_results.py
@@ -19,9 +19,9 @@ logger = logging.getLogger("murfey.workflows.clem.register_align_and_merge_resul
 class AlignAndMergeResult(BaseModel):
     series_name: str
     image_stacks: list[Path]
-    align_self: Optional[str] = None
-    flatten: Optional[str] = "mean"
-    align_across: Optional[str] = None
+    align_self: bool = False
+    flatten: bool = True
+    align_across: bool = False
     output_file: Path
     thumbnail: Optional[Path] = None
     thumbnail_size: Optional[tuple[int, int]] = None

--- a/tests/workflows/clem/test_register_align_and_merge_results.py
+++ b/tests/workflows/clem/test_register_align_and_merge_results.py
@@ -74,9 +74,9 @@ def test_run(
         "result": {
             "series_name": incoming_series_name,
             "image_stacks": [],
-            "align_self": None,
-            "flatten": None,
-            "align_across": None,
+            "align_self": False,
+            "flatten": True,
+            "align_across": False,
             "output_file": tmp_path / "dummy",
             "thumbnail": None,
             "thumbnail_size": None,


### PR DESCRIPTION
This PR updates Murfey so that it can correctly register the updated output from the CLEM `align_and_merge` service in `cryoemservices` (see https://github.com/DiamondLightSource/cryoem-services/pull/267).