### PR TITLE
Initial model cube name fix

### DIFF
--- a/src/murfey/server/feedback.py
+++ b/src/murfey/server/feedback.py
@@ -1088,6 +1088,7 @@ def _resize_initial_model(
         input_size_z = input_mrc.header.nz
     if executables.get("clip") and not input_size_x == input_size_y == input_size_z:
         # If the initial model is not a cube, do some padding
+        input_path_cube = input_path.parent / f"{input_path.stem}_cube.mrc"
         clip_proc = subprocess.run(
             [
                 f"{executables['clip']}",
@@ -1099,13 +1100,13 @@ def _resize_initial_model(
                 "-oz",
                 str(max(input_size_x, input_size_y, input_size_z)),
                 str(input_path),
-                str(input_path.with_suffix("_cube.mrc")),
+                str(input_path_cube),
             ],
             capture_output=True,
             text=True,
             env=env,
         )
-        input_path = input_path.with_suffix("_cube.mrc")
+        input_path = input_path_cube
         if clip_proc.returncode:
             logger.error(
                 f"Clipping initial model {input_path} failed \n {clip_proc.stdout}"


### PR DESCRIPTION
I found I had this uncommitted from a while ago. It's a direct bug in the user-supplied initial model logic