### PR TITLE
Skip processing for SXT stacks where all angles are zero

### DIFF
--- a/src/murfey/client/contexts/sxt.py
+++ b/src/murfey/client/contexts/sxt.py
@@ -76,6 +76,38 @@ class SXTContext(Context):
         self._basepath = basepath
         self._machine_config = machine_config
 
+    def determined_converted_tiff_path(
+        self,
+        transferred_file: Path,
+        environment: MurfeyInstanceEnvironment,
+        source: Path,
+    ):
+        """Find the output path of a converted txrm file in the processed directory"""
+        if environment.visit in Path(environment.default_destinations[source]).parts:
+            # Split either side of the raw directory
+            visit_idx = Path(environment.default_destinations[source]).parts.index(
+                environment.visit
+            )
+            destination_base = "/".join(
+                Path(environment.default_destinations[source]).parts[: visit_idx + 1]
+            )
+            destination_extra = "/".join(
+                Path(environment.default_destinations[source]).parts[visit_idx + 2 :]
+            )
+        else:
+            destination_base = str(
+                Path(environment.default_destinations[source]) / environment.visit
+            )
+            destination_extra = ""
+        return (
+            Path(self._machine_config.get("rsync_basepath", ""))
+            / destination_base
+            / self._machine_config.get("processed_directory_name", "")
+            / self._machine_config.get("processed_extra_directory", "")
+            / destination_extra
+            / f"{transferred_file.relative_to(source).stem}_Annotated.tiff"
+        )
+
     def register_sxt_data_collection(
         self,
         tilt_series: str,
@@ -224,37 +256,8 @@ class SXTContext(Context):
                     transferred_file,
                     Path(self._machine_config.get("rsync_basepath", "")),
                 )
-                if (
-                    environment.visit
-                    in Path(environment.default_destinations[source]).parts
-                ):
-                    # Split either side of the raw directory
-                    visit_idx = Path(
-                        environment.default_destinations[source]
-                    ).parts.index(environment.visit)
-                    destination_base = "/".join(
-                        Path(environment.default_destinations[source]).parts[
-                            : visit_idx + 1
-                        ]
-                    )
-                    destination_extra = "/".join(
-                        Path(environment.default_destinations[source]).parts[
-                            visit_idx + 2 :
-                        ]
-                    )
-                else:
-                    destination_base = str(
-                        Path(environment.default_destinations[source])
-                        / environment.visit
-                    )
-                    destination_extra = ""
-                converted_tiff_path = (
-                    Path(self._machine_config.get("rsync_basepath", ""))
-                    / destination_base
-                    / self._machine_config.get("processed_directory_name", "")
-                    / self._machine_config.get("processed_extra_directory", "")
-                    / destination_extra
-                    / f"{transferred_file.relative_to(source).stem}_Annotated.tiff"
+                converted_tiff_path = self.determined_converted_tiff_path(
+                    transferred_file, environment, source
                 )
                 thumbnail_path = converted_tiff_path.parent / (
                     converted_tiff_path.stem + "_thumbnail.jpg"
@@ -416,6 +419,34 @@ class SXTContext(Context):
             else:
                 reference_file = None
 
+            logger.info(
+                f"The following tilt series will be processed: {transferred_file.stem}"
+            )
+            file_transferred_to = _file_transferred_to(
+                environment,
+                source,
+                transferred_file,
+                Path(self._machine_config.get("rsync_basepath", "")),
+            )
+
+            if not angles or all(angles) == 0:
+                logger.info(f"All angles in {transferred_file.stem} are zero")
+                converted_tiff_path = self.determined_converted_tiff_path(
+                    transferred_file, environment, source
+                )
+                capture_post(
+                    base_url=str(environment.url.geturl()),
+                    router_name="workflow_sxt.router",
+                    function_name="convert_xrm_to_tiff",
+                    token=self._token,
+                    instrument_name=environment.instrument_name,
+                    data={
+                        "xrm_path": str(file_transferred_to),
+                        "tiff_path": str(converted_tiff_path),
+                    },
+                )
+                return True
+
             if "@" in transferred_file.stem:
                 tilt_series_tag = "_".join(
                     transferred_file.stem.split("@")[0].split("_")[:-1]
@@ -441,15 +472,6 @@ class SXTContext(Context):
                 environment=environment,
             )
 
-            logger.info(
-                f"The following tilt series will be processed: {transferred_file.stem}"
-            )
-            file_transferred_to = _file_transferred_to(
-                environment,
-                source,
-                transferred_file,
-                Path(self._machine_config.get("rsync_basepath", "")),
-            )
             if reference_file:
                 reference_file_transferred_to = _file_transferred_to(
                     environment,

--- a/src/murfey/client/contexts/sxt.py
+++ b/src/murfey/client/contexts/sxt.py
@@ -76,7 +76,7 @@ class SXTContext(Context):
         self._basepath = basepath
         self._machine_config = machine_config
 
-    def determined_converted_tiff_path(
+    def determine_converted_tiff_path(
         self,
         transferred_file: Path,
         environment: MurfeyInstanceEnvironment,
@@ -256,7 +256,7 @@ class SXTContext(Context):
                     transferred_file,
                     Path(self._machine_config.get("rsync_basepath", "")),
                 )
-                converted_tiff_path = self.determined_converted_tiff_path(
+                converted_tiff_path = self.determine_converted_tiff_path(
                     transferred_file, environment, source
                 )
                 thumbnail_path = converted_tiff_path.parent / (
@@ -431,7 +431,7 @@ class SXTContext(Context):
 
             if not angles or all(angles) == 0:
                 logger.info(f"All angles in {transferred_file.stem} are zero")
-                converted_tiff_path = self.determined_converted_tiff_path(
+                converted_tiff_path = self.determine_converted_tiff_path(
                     transferred_file, environment, source
                 )
                 capture_post(

--- a/tests/client/contexts/test_sxt.py
+++ b/tests/client/contexts/test_sxt.py
@@ -475,7 +475,7 @@ def test_sxt_context_txrm_zero_angles(mock_ole_file, mock_post, tmp_path):
     mock_post.assert_any_call(
         "http://localhost:8000/workflow/sxt/convert_xrm_to_tiff",
         json={
-            "xrm_path": str(tmp_path / "destination/cm12345-6/grid1/example_0.txrm"),
+            "xrm_path": "/path/to/dest/cm12345-6/raw/grid1/example_0.txrm",
             "tiff_path": "/path/to/dest/cm12345-6/processed/grid1/example_0_Annotated.tiff",
         },
         headers={"Authorization": "Bearer "},

--- a/tests/client/contexts/test_sxt.py
+++ b/tests/client/contexts/test_sxt.py
@@ -415,3 +415,68 @@ def test_sxt_context_txrm_external_ref(mock_ole_file, mock_post, tmp_path):
         },
         headers={"Authorization": "Bearer "},
     )
+
+
+@patch("requests.post")
+@patch("murfey.client.contexts.sxt.OleFileIO")
+def test_sxt_context_txrm_zero_angles(mock_ole_file, mock_post, tmp_path):
+    mock_post().status_code = 200
+    exists_return = [False]  # False for reference, then True
+    exists_return.extend([True for i in range(20)])
+    mock_ole_file().__enter__().exists.side_effect = exists_return
+    # Motor position names
+    mock_ole_file().__enter__().openstream().read.return_value = (
+        "\x00Val1\x00\x00Energy\x00".encode()
+    )
+    # Metadata encoded arrays
+    mock_ole_file().__enter__().openstream().getvalue.side_effect = [
+        np.array([0, 0, 0, 0, 0], dtype=np.float32).tobytes(),  # Angles
+        np.array([0.01001], dtype=np.float32).tobytes(),  # Pixel size
+        np.array([1024], dtype=np.int32).tobytes(),  # Image Width
+        np.array([2048], dtype=np.int32).tobytes(),  # Image Height
+        np.array([1.5], dtype=np.float32).tobytes(),  # Exposure time
+        np.array([1000], dtype=np.float32).tobytes(),  # Mag
+        np.array([200], dtype=np.int32).tobytes(),  # Image count
+        np.array([0, 519, 2, 3], dtype=np.float32).tobytes(),  # Motor Pos (energy)
+        np.array([0], dtype=np.int32).tobytes(),  # Mosaic size
+        np.array([0], dtype=np.int32).tobytes(),  # Mosaic size
+    ]
+
+    # xrm file as reference
+    (tmp_path / "cm12345-6/grid1").mkdir(parents=True)
+    (tmp_path / "cm12345-6/grid1/ref.xrm").touch()
+
+    env = MurfeyInstanceEnvironment(
+        url=urlparse("http://localhost:8000"),
+        client_id=0,
+        sources=[tmp_path / "cm12345-6/grid1"],
+        default_destinations={f"{tmp_path}/cm12345-6/grid1": "cm12345-6/raw/grid1"},
+        instrument_name="",
+        visit="cm12345-6",
+        murfey_session=1,
+    )
+    context = SXTContext(
+        "zeiss",
+        tmp_path / "cm12345-6/grid1",
+        {"rsync_basepath": "/path/to/dest", "processed_directory_name": "processed"},
+        "",
+    )
+    context.post_transfer(
+        tmp_path / "cm12345-6/grid1/example_0.txrm",
+        required_position_files=[],
+        required_strings=["fractions"],
+        environment=env,
+    )
+
+    mock_ole_file.assert_any_call(str(tmp_path / "cm12345-6/grid1/example_0.txrm"))
+    mock_ole_file.assert_any_call(str(tmp_path / "cm12345-6/grid1/ref.xrm"))
+
+    assert mock_post.call_count == 2
+    mock_post.assert_any_call(
+        "http://localhost:8000/workflow/sxt/convert_xrm_to_tiff",
+        json={
+            "xrm_path": str(tmp_path / "destination/cm12345-6/grid1/example_0.txrm"),
+            "tiff_path": "/path/to/dest/cm12345-6/processed/grid1/example_0_Annotated.tiff",
+        },
+        headers={"Authorization": "Bearer "},
+    )


### PR DESCRIPTION
It doesn't make sense to treat stacks as tomograms if there are no tilts!

TBC exactly what these are, but they appear to be focus scans on the SXT instrument. AreTomo is able to process them, but Imod is not.
Instead just do the txrm to tiff conversion for any stacks which contain only zero-degree tilts.

There is very little new code here, but a few bits have moved around to reuse the tiff path creation and get the right posts.