### PR TITLE
Workarounds in reposting failed calls

### DIFF
--- a/src/murfey/cli/repost_failed_calls.py
+++ b/src/murfey/cli/repost_failed_calls.py
@@ -136,10 +136,19 @@ def handle_failed_posts(messages_path: list[Path], murfey_db: Session):
             for call_arg in expected_args.args:
                 call_arg_type = expected_args.annotations.get(call_arg, str)
                 if call_arg in call_kwargs.keys():
-                    function_call_dict[call_arg] = call_arg_type(call_kwargs[call_arg])
+                    function_call_dict[call_arg] = (
+                        call_arg_type(call_kwargs[call_arg])
+                        if str(call_arg_type) != "str"
+                        else call_kwargs[call_arg]
+                    )
                 elif call_arg == "db":
                     function_call_dict["db"] = murfey_db
                 else:
+                    if isinstance(call_arg_type, str):
+                        try:
+                            call_arg_type = getattr(murfey.util.models, call_arg_type)
+                        except Exception as e:
+                            print(f"Failed to find type: {e}")
                     print(call_data, call_arg_type, call_arg)
                     function_call_dict[call_arg] = call_arg_type(**call_data)
         except TypeError as e:

--- a/src/murfey/workflows/spa/flush_spa_preprocess.py
+++ b/src/murfey/workflows/spa/flush_spa_preprocess.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 from PIL import Image
+from sqlalchemy import desc
 from sqlalchemy.exc import NoResultFound
 from sqlmodel import Session, select
 
@@ -70,13 +71,15 @@ def register_grid_square(
             select(DataCollectionGroup)
             .where(DataCollectionGroup.session_id == session_id)
             .where(DataCollectionGroup.sample == grid_square_params.sample)
-        ).one()
+            .order_by(desc(DataCollectionGroup.id))
+        ).first()
     else:
         dcg = murfey_db.exec(
             select(DataCollectionGroup)
             .where(DataCollectionGroup.session_id == session_id)
             .where(DataCollectionGroup.tag == grid_square_params.tag)
-        ).one()
+            .order_by(desc(DataCollectionGroup.id))
+        ).first()
     grid_square_query = murfey_db.exec(
         select(GridSquare)
         .where(GridSquare.name == gsid)


### PR DESCRIPTION
For some reason the `repost_failed_calls` function does not always pick up the type correctly. This addresses that by doing a lookup if the type ends up as a string.

Also for grid squares takes the last one, to partly address the problems when grid slots are duplicated.