### PR TITLE
Allow reprocessing of files for SXT

### DIFF
--- a/src/murfey/workflows/sxt/process_sxt_tilt_series.py
+++ b/src/murfey/workflows/sxt/process_sxt_tilt_series.py
@@ -48,7 +48,6 @@ def process_sxt_tilt_series(
         tilt_series = tilt_series_query[0]
         if tilt_series.processing_requested:
             logger.info(f"Tilt series {tilt_series.tag} has already been processed")
-            # return {"success": True}
     else:
         tilt_series = TiltSeries(
             session_id=session_id,

--- a/src/murfey/workflows/sxt/process_sxt_tilt_series.py
+++ b/src/murfey/workflows/sxt/process_sxt_tilt_series.py
@@ -48,7 +48,7 @@ def process_sxt_tilt_series(
         tilt_series = tilt_series_query[0]
         if tilt_series.processing_requested:
             logger.info(f"Tilt series {tilt_series.tag} has already been processed")
-            return {"success": True}
+            # return {"success": True}
     else:
         tilt_series = TiltSeries(
             session_id=session_id,


### PR DESCRIPTION
Do not skip processing for SXT files which were already processed, as they may have a new reference attached.

This will trigger reprocessing on session reconnection, which isn't ideal but is probably ok for now